### PR TITLE
Release 5.0

### DIFF
--- a/ControleMateriais.Desktop/ControleMateriais.Desktop.csproj
+++ b/ControleMateriais.Desktop/ControleMateriais.Desktop.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
     <PackageReference Include="itext7" Version="8.0.5" />
+    <PackageReference Include="ClosedXML" Version="0.104.1" />
 	<PackageReference Include="QuestPDF" Version="2024.12.3" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12">

--- a/ControleMateriais.Desktop/Services/ReciboParserService.cs
+++ b/ControleMateriais.Desktop/Services/ReciboParserService.cs
@@ -1,0 +1,218 @@
+using ControleMateriais.Desktop;
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ControleMateriais.Desktop.Services;
+
+/// <summary>
+/// Extrai os itens e pesos (kg) de um PDF de recibo de pesagem da LFB.
+/// </summary>
+public static class ReciboParserService
+{
+    // Linhas que identificam cabeçalhos/rodapés a ignorar
+    private static readonly HashSet<string> _linhasIgnoradas = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "material", "kg", "valor/kg", "total", "fornecedor", "peso", "valor", "data",
+        "lfb reciclagem eletronica", "resultado da pesagem e triagem lfb",
+        "cnpj", "impurezas"
+    };
+
+    // Regex: número com 3 casas decimais no formato brasileiro (ex: 22,710 ou 1.234,567)
+    private static readonly Regex _rePeso = new(
+        @"(?<!\d)([\d]{1,3}(?:\.\d{3})*,\d{3})(?!\d)|(?<!\d)(\d+,\d{3})(?!\d)",
+        RegexOptions.Compiled);
+
+    // Corrige artefato do iText: "2 2,710" → "22,710"
+    private static readonly Regex _reEspacoDigitos = new(@"(\d) (\d)", RegexOptions.Compiled);
+
+    // Aliases para nomes que podem aparecer diferente no PDF extraído
+    private static readonly Dictionary<string, string[]> _aliases =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["HD sem placa/Sucateado"]                  = ["HD sem Placa Sucateado", "HD sem Placa", "HD Sucateado"],
+            ["Celular Smart sem Bateria Botão e Flip"]  = ["Celular Sem bateria Botao e Flip", "Celular Sem bateria Botão e Flip", "Sem bateria Botao e Flip"],
+            ["Celular Replicas com e sem Baterias"]     = ["Celular Replicas com e sem Bateria", "Replicas com e sem Baterias"],
+            ["Memória Prata"]                           = ["Memorias Prata", "Memórias Prata", "Memoria Prateada"],
+            ["Memórias Douradas"]                       = ["Memorias Douradas", "Memoria Dourada"],
+            ["Desmanche Eletrônicos Consultar"]         = ["Desmanche Eletronicos Consultar", "Desmanche Eletrônicos Consultar Itens", "Desmanche Eletronicos"],
+        };
+
+    /// <summary>
+    /// Lê o PDF e retorna {nomeMaterial → peso em kg}.
+    /// Inclui itens do catálogo E itens extras (não catalogados) encontrados no PDF.
+    /// </summary>
+    public static Dictionary<string, decimal> ExtrairPesos(string filePath)
+    {
+        var resultado = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+
+        var linhas = ExtrairLinhasPdf(filePath);
+        CorrigirEspacosEntreDigitos(linhas);
+        var linhasNorm = linhas.Select(NormalizarTexto).ToList();
+
+        // ── Passo 1: itens do catálogo (prioridade por comprimento decrescente) ──
+        var catalogoOrdenado = ItemCatalog.OrderedItems
+            .OrderByDescending(n => n.Length)
+            .ToList();
+
+        var linhasConsumidas = new HashSet<int>();
+
+        foreach (var nome in catalogoOrdenado)
+        {
+            var termos = new List<string> { NormalizarTexto(nome) };
+            if (_aliases.TryGetValue(nome, out var alts))
+                termos.AddRange(alts.Select(NormalizarTexto));
+
+            for (int i = 0; i < linhas.Count; i++)
+            {
+                if (!termos.Any(t => linhasNorm[i].Contains(t, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+
+                decimal? val = null;
+                int linhaVal = -1;
+
+                if (!linhasConsumidas.Contains(i))
+                {
+                    val = ExtrairPrimeiroPeso(linhas[i]);
+                    if (val.HasValue) linhaVal = i;
+                }
+
+                for (int j = i + 1; val is null && j <= i + 2 && j < linhas.Count; j++)
+                {
+                    if (linhasConsumidas.Contains(j)) break;
+                    bool outraItem = catalogoOrdenado.Any(n => n != nome &&
+                        linhasNorm[j].Contains(NormalizarTexto(n), StringComparison.OrdinalIgnoreCase));
+                    if (outraItem) break;
+                    val = ExtrairPrimeiroPeso(linhas[j]);
+                    if (val.HasValue) linhaVal = j;
+                }
+
+                if (val.HasValue)
+                {
+                    resultado[nome] = val.Value;
+                    linhasConsumidas.Add(i);
+                    if (linhaVal >= 0 && linhaVal != i) linhasConsumidas.Add(linhaVal);
+                    break;
+                }
+            }
+        }
+
+        // ── Passo 2: itens extras (não catalogados) ───────────────────────────
+        // Procura linhas não consumidas que parecem ser nomes seguidos de um peso N3
+        // Heurística: linha de texto puro (sem dígitos) + linha seguinte com peso N3
+        var nomesExtraEncontrados = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < linhas.Count - 1; i++)
+        {
+            if (linhasConsumidas.Contains(i)) continue;
+
+            var linha = linhas[i].Trim();
+            if (string.IsNullOrWhiteSpace(linha)) continue;
+
+            // Descarta linhas que são sabidamente cabeçalho/rodapé
+            var linhaNorm = NormalizarTexto(linha);
+            if (_linhasIgnoradas.Any(ig => linhaNorm.Contains(ig, StringComparison.OrdinalIgnoreCase))) continue;
+
+            // Ignora linhas que são só números/datas/R$
+            if (Regex.IsMatch(linha, @"^[\d\s,./R$%]+$")) continue;
+
+            // Ignora se já é um item do catálogo
+            if (catalogoOrdenado.Any(n => linhaNorm.Contains(NormalizarTexto(n), StringComparison.OrdinalIgnoreCase))) continue;
+
+            // Tenta encontrar o peso nessa linha ou na próxima
+            decimal? peso = ExtrairPrimeiroPeso(linha);
+            int linhaVal = peso.HasValue ? i : -1;
+
+            if (!peso.HasValue && i + 1 < linhas.Count && !linhasConsumidas.Contains(i + 1))
+            {
+                peso = ExtrairPrimeiroPeso(linhas[i + 1]);
+                if (peso.HasValue) linhaVal = i + 1;
+            }
+
+            if (!peso.HasValue) continue;
+
+            // Remove dígitos e símbolos do nome, deixa só o texto
+            var nomeExtra = Regex.Replace(linha, @"[\d,./R$%]", "").Trim();
+            nomeExtra = Regex.Replace(nomeExtra, @"\s{2,}", " ").Trim();
+            if (string.IsNullOrWhiteSpace(nomeExtra) || nomeExtra.Length < 2) continue;
+
+            // Evita duplicatas com o catálogo
+            if (catalogoOrdenado.Any(n => NormalizarTexto(n).Equals(NormalizarTexto(nomeExtra), StringComparison.OrdinalIgnoreCase))) continue;
+
+            if (!nomesExtraEncontrados.Contains(nomeExtra))
+            {
+                nomesExtraEncontrados.Add(nomeExtra);
+                resultado[nomeExtra] = resultado.TryGetValue(nomeExtra, out var existing) ? existing + peso.Value : peso.Value;
+                linhasConsumidas.Add(i);
+                if (linhaVal >= 0 && linhaVal != i) linhasConsumidas.Add(linhaVal);
+            }
+        }
+
+        return resultado;
+    }
+
+    private static List<string> ExtrairLinhasPdf(string filePath)
+    {
+        var linhas = new List<string>();
+        using var reader = new PdfReader(filePath);
+        using var doc = new PdfDocument(reader);
+        for (int p = 1; p <= doc.GetNumberOfPages(); p++)
+        {
+            var strategy = new LocationTextExtractionStrategy();
+            var text = PdfTextExtractor.GetTextFromPage(doc.GetPage(p), strategy);
+            foreach (var l in text.Split('\n'))
+            {
+                var trimmed = l.Trim();
+                if (!string.IsNullOrWhiteSpace(trimmed))
+                    linhas.Add(trimmed);
+            }
+        }
+        return linhas;
+    }
+
+    private static void CorrigirEspacosEntreDigitos(List<string> linhas)
+    {
+        for (int i = 0; i < linhas.Count; i++)
+        {
+            string orig;
+            do
+            {
+                orig = linhas[i];
+                linhas[i] = _reEspacoDigitos.Replace(orig, "$1$2");
+            } while (linhas[i] != orig);
+        }
+    }
+
+    private static decimal? ExtrairPrimeiroPeso(string linha)
+    {
+        var m = _rePeso.Match(linha);
+        if (!m.Success) return null;
+
+        for (int g = 1; g < m.Groups.Count; g++)
+        {
+            var raw = m.Groups[g].Value.Trim();
+            if (string.IsNullOrEmpty(raw)) continue;
+            raw = raw.Replace(".", "").Replace(",", ".");
+            if (decimal.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out var val))
+                return val;
+        }
+        return null;
+    }
+
+    private static string NormalizarTexto(string texto)
+    {
+        var normalizado = texto.Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(normalizado.Length);
+        foreach (var c in normalizado)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                sb.Append(c);
+        }
+        return sb.ToString().ToLowerInvariant().Trim();
+    }
+}

--- a/ControleMateriais.Desktop/Services/ReconstruirBancoDadosService.cs
+++ b/ControleMateriais.Desktop/Services/ReconstruirBancoDadosService.cs
@@ -1,0 +1,141 @@
+using ControleMateriais.Desktop.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace ControleMateriais.Desktop.Services;
+
+public static class ReconstruirBancoDadosService
+{
+    /// <summary>
+    /// Apaga todos os .json em banco-de-dados/ (exceto .git/), regera um JSON por PDF de pesagem
+    /// e grava um novo estoque.json = Σ pesagens − Σ vendas.
+    /// </summary>
+    public static void Reconstruir(string rootDir, Action<string>? progresso = null)
+    {
+        var bancoDadosDir = GitHubService.BancoDadosRepoDir(rootDir);
+        var recibosDir    = GitHubService.RecibosRepoDir(rootDir);
+        var vendaDir      = Path.Combine(recibosDir, "Recibos_Venda");
+
+        // ── 1. Apagar todos os .json existentes em banco-de-dados/ ────────────
+        progresso?.Invoke("Removendo JSONs antigos...");
+        if (Directory.Exists(bancoDadosDir))
+        {
+            foreach (var f in Directory.GetFiles(bancoDadosDir, "*.json", SearchOption.TopDirectoryOnly))
+                File.Delete(f);
+        }
+        else
+        {
+            Directory.CreateDirectory(bancoDadosDir);
+        }
+
+        // ── 2. Processar cada PDF de pesagem → gerar JSON ────────────────────
+        var pdfs = Directory.Exists(recibosDir)
+            ? Directory.GetFiles(recibosDir, "*.pdf", SearchOption.TopDirectoryOnly)
+                       .OrderBy(f => f)
+                       .ToList()
+            : new List<string>();
+
+        progresso?.Invoke($"Processando {pdfs.Count} recibos de pesagem...");
+
+        var totaisPesagem = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        int gerados = 0;
+
+        for (int i = 0; i < pdfs.Count; i++)
+        {
+            var pdf = pdfs[i];
+            progresso?.Invoke($"Pesagem {i + 1}/{pdfs.Count}: {Path.GetFileName(pdf)}");
+
+            Dictionary<string, decimal> itens;
+            try { itens = ReciboParserService.ExtrairPesos(pdf); }
+            catch { continue; }
+
+            if (itens.Count == 0) continue;
+
+            // Acumular no total de pesagem
+            foreach (var kv in itens)
+                totaisPesagem[kv.Key] = totaisPesagem.TryGetValue(kv.Key, out var atual)
+                    ? atual + kv.Value
+                    : kv.Value;
+
+            // Gerar JSON com mesmo nome do PDF (trocando extensão)
+            var nomeSemExt  = Path.GetFileNameWithoutExtension(pdf);
+            var dataStr     = ExtrairDataDoNome(pdf);
+            var jsonPath    = Path.Combine(bancoDadosDir, nomeSemExt + ".json");
+
+            var obj = new JsonObject();
+            foreach (var kv in itens.OrderBy(k => k.Key))
+                obj[kv.Key] = JsonValue.Create(kv.Value);
+            obj["data"]   = dataStr;
+            obj["status"] = "Adicionado ao estoque";
+
+            File.WriteAllText(jsonPath,
+                obj.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            gerados++;
+        }
+
+        progresso?.Invoke($"{gerados} JSONs gerados. Processando recibos de venda...");
+
+        // ── 3. Subtrair vendas ───────────────────────────────────────────────
+        var totaisEstoque = new Dictionary<string, decimal>(totaisPesagem, StringComparer.OrdinalIgnoreCase);
+
+        if (Directory.Exists(vendaDir))
+        {
+            var vendaPdfs = Directory.GetFiles(vendaDir, "*.pdf", SearchOption.TopDirectoryOnly)
+                                     .OrderBy(f => f)
+                                     .ToList();
+
+            progresso?.Invoke($"Subtraindo {vendaPdfs.Count} recibos de venda...");
+
+            for (int i = 0; i < vendaPdfs.Count; i++)
+            {
+                var pdf = vendaPdfs[i];
+                progresso?.Invoke($"Venda {i + 1}/{vendaPdfs.Count}: {Path.GetFileName(pdf)}");
+
+                Dictionary<string, decimal> itensVenda;
+                try { itensVenda = ReciboParserService.ExtrairPesos(pdf); }
+                catch { continue; }
+
+                foreach (var kv in itensVenda)
+                {
+                    if (totaisEstoque.TryGetValue(kv.Key, out var atual))
+                        totaisEstoque[kv.Key] = Math.Max(0m, atual - kv.Value);
+                }
+            }
+        }
+
+        // Remove itens com peso zero ou negativo
+        foreach (var key in totaisEstoque.Keys.ToList())
+        {
+            if (totaisEstoque[key] <= 0m)
+                totaisEstoque.Remove(key);
+        }
+
+        // ── 4. Gravar estoque.json ────────────────────────────────────────────
+        progresso?.Invoke("Gravando estoque.json...");
+        EstoqueViewModel.GravarEstoque(rootDir, totaisEstoque);
+
+        progresso?.Invoke($"Concluído. {gerados} JSONs + estoque.json gravados.");
+    }
+
+    private static string ExtrairDataDoNome(string filePath)
+    {
+        var semExt = Path.GetFileNameWithoutExtension(filePath);
+
+        var m1 = System.Text.RegularExpressions.Regex.Match(semExt, @"_(\d{2}-\d{2}-\d{4})_\d{2}-\d{2}$");
+        if (m1.Success && DateTime.TryParseExact(m1.Groups[1].Value, "dd-MM-yyyy",
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt1))
+            return dt1.ToString("dd-MM-yyyy");
+
+        var m2 = System.Text.RegularExpressions.Regex.Match(semExt, @"_(\d{2}-\d{2}-\d{4})");
+        if (m2.Success && DateTime.TryParseExact(m2.Groups[1].Value, "dd-MM-yyyy",
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt2))
+            return dt2.ToString("dd-MM-yyyy");
+
+        return File.GetLastWriteTime(filePath).ToString("dd-MM-yyyy");
+    }
+}

--- a/ControleMateriais.Desktop/Services/RelatorioExcelService.cs
+++ b/ControleMateriais.Desktop/Services/RelatorioExcelService.cs
@@ -21,12 +21,12 @@ public static class RelatorioExcelService
     /// <param name="progresso">Callback opcional para reportar progresso (mensagem)</param>
     public static void Gerar(string recibosDir, string outputPath, Action<string>? progresso = null)
     {
-        // ── 1. Listar PDFs (ignora subpastas como Recibos_Venda) ─────────────
+        // ── 1. Listar PDFs de pesagem (ignora subpastas como Recibos_Venda) ──
         var pdfs = Directory.GetFiles(recibosDir, "*.pdf", SearchOption.TopDirectoryOnly)
             .OrderBy(f => f)
             .ToList();
 
-        // ── 2. Extrair dados de cada PDF ──────────────────────────────────────
+        // ── 2. Extrair dados de cada PDF de pesagem ───────────────────────────
         // dataStr → {nomeItem → pesoTotal do dia}
         var porDia = new Dictionary<string, Dictionary<string, decimal>>(StringComparer.OrdinalIgnoreCase);
         // todos os nomes de itens extras encontrados
@@ -58,32 +58,77 @@ public static class RelatorioExcelService
             }
         }
 
-        // ── 3. Ordenar datas (colunas) de mais antiga a mais recente ─────────
+        // ── 3. Ordenar datas de pesagem de mais antiga a mais recente ─────────
         var datas = porDia.Keys
             .OrderBy(d => ParseData(d))
             .ToList();
 
-        // ── 4. Montar lista de linhas: catálogo + extras alfabético ───────────
+        // ── 4. Listar PDFs de venda (Recibos_Venda/) ─────────────────────────
+        var vendaDir  = Path.Combine(recibosDir, "Recibos_Venda");
+        var pdfsVenda = Directory.Exists(vendaDir)
+            ? Directory.GetFiles(vendaDir, "*.pdf", SearchOption.TopDirectoryOnly).OrderBy(f => f).ToList()
+            : new List<string>();
+
+        var porDiaVenda = new Dictionary<string, Dictionary<string, decimal>>(StringComparer.OrdinalIgnoreCase);
+
+        int contadorVenda = 0;
+        foreach (var pdf in pdfsVenda)
+        {
+            contadorVenda++;
+            var dataStr = ExtrairDataDoNome(pdf);
+            progresso?.Invoke($"Venda {contadorVenda}/{pdfsVenda.Count}: {Path.GetFileName(pdf)}");
+
+            Dictionary<string, decimal> itens;
+            try { itens = ReciboParserService.ExtrairPesos(pdf); }
+            catch { continue; }
+
+            if (!porDiaVenda.TryGetValue(dataStr, out var diaDict))
+            {
+                diaDict = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+                porDiaVenda[dataStr] = diaDict;
+            }
+
+            foreach (var kv in itens)
+                diaDict[kv.Key] = diaDict.TryGetValue(kv.Key, out var atual) ? atual + kv.Value : kv.Value;
+        }
+
+        var datasVenda = porDiaVenda.Keys
+            .OrderBy(d => ParseData(d))
+            .ToList();
+
+        // ── 5. Montar lista de linhas: catálogo + extras alfabético ───────────
         var linhasItens = ItemCatalog.OrderedItems
             .Concat(extrasGlobal.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
             .ToList();
 
-        // ── 5. Gerar Excel ────────────────────────────────────────────────────
+        // ── 6. Gerar Excel ────────────────────────────────────────────────────
         progresso?.Invoke("Gerando Excel...");
 
         using var wb = new XLWorkbook();
         var ws = wb.Worksheets.Add("Pesagens por Dia");
 
-        // Estilo base
+        // Cores — pesagens (verde)
         var headerFill  = XLColor.FromHtml("#2E7D32");
         var headerFont  = XLColor.White;
         var totalFill   = XLColor.FromHtml("#E8F5E9");
         var extraFill   = XLColor.FromHtml("#FFF8E1");
         var borderColor = XLColor.FromHtml("#BDBDBD");
 
-        int colOffset = 2; // coluna A = nome do item, dados a partir de B
+        // Cores — vendas (laranja)
+        var vendaHeaderFill      = XLColor.FromHtml("#E65100");
+        var vendaTotalColFill    = XLColor.FromHtml("#FFF3E0");
+        var vendaGrandTotalFill  = XLColor.FromHtml("#FFE0B2");
+        var vendaTotalHeaderFill = XLColor.FromHtml("#BF360C");
 
-        // ── Cabeçalho linha 1: "Item" + datas + "TOTAL" ─────────────────────
+        // Cores — estoque atual (azul)
+        var estoqueHeaderFill     = XLColor.FromHtml("#0D47A1");
+        var estoqueCellFill       = XLColor.FromHtml("#E3F2FD");
+        var estoqueGrandTotalFill = XLColor.FromHtml("#BBDEFB");
+
+        int colOffset     = 2;                              // coluna A = nomes, B em diante = datas pesagem
+        int colVendaStart = colOffset + datas.Count + 1;   // primeira coluna de venda (após TOTAL verde)
+
+        // ── Cabeçalho linha 1: "Item" + datas pesagem + "TOTAL" ──────────────
         var cellItem = ws.Cell(1, 1);
         cellItem.Value = "Item";
         EstiloHeader(cellItem, headerFill, headerFont);
@@ -99,11 +144,31 @@ public static class RelatorioExcelService
         cellTotal.Value = "TOTAL";
         EstiloHeader(cellTotal, XLColor.FromHtml("#1B5E20"), headerFont);
 
+        // ── Cabeçalho linha 1: datas venda + "TOTAL VENDAS" ──────────────────
+        for (int d = 0; d < datasVenda.Count; d++)
+        {
+            var cell = ws.Cell(1, colVendaStart + d);
+            cell.Value = datasVenda[d];
+            EstiloHeader(cell, vendaHeaderFill, headerFont);
+        }
+
+        if (datasVenda.Count > 0)
+        {
+            var cellTotalVendas = ws.Cell(1, colVendaStart + datasVenda.Count);
+            cellTotalVendas.Value = "TOTAL VENDAS";
+            EstiloHeader(cellTotalVendas, vendaTotalHeaderFill, headerFont);
+        }
+
+        // ── Cabeçalho: "Estoque Atual" ────────────────────────────────────────
+        int colEstoqueAtual = (datasVenda.Count > 0 ? colVendaStart + datasVenda.Count + 1 : colOffset + datas.Count + 1);
+        var cellEstoqueHeader = ws.Cell(1, colEstoqueAtual);
+        cellEstoqueHeader.Value = "Estoque Atual";
+        EstiloHeader(cellEstoqueHeader, estoqueHeaderFill, headerFont);
+
         // ── Linhas de itens ───────────────────────────────────────────────────
         var extrasExistem = extrasGlobal.Count > 0;
-        int excelRow = 2; // linha 1 = cabeçalho
+        int excelRow = 2;
 
-        // Itens do catálogo
         var itensFixos = linhasItens
             .Where(n => ItemCatalog.OrderedItems.Contains(n, StringComparer.OrdinalIgnoreCase))
             .ToList();
@@ -118,6 +183,7 @@ public static class RelatorioExcelService
             cellNome.Style.Font.Bold = !isExtra;
             if (isExtra) cellNome.Style.Fill.BackgroundColor = extraFill;
 
+            // — colunas de pesagem —
             decimal rowTotal = 0m;
             for (int d = 0; d < datas.Count; d++)
             {
@@ -130,6 +196,29 @@ public static class RelatorioExcelService
             var cellRowTotal = ws.Cell(excelRow, colOffset + datas.Count);
             if (rowTotal > 0) { cellRowTotal.Value = rowTotal; cellRowTotal.Style.NumberFormat.Format = "#,##0.000"; cellRowTotal.Style.Font.Bold = true; }
             cellRowTotal.Style.Fill.BackgroundColor = totalFill;
+
+            // — colunas de venda —
+            decimal rowTotalVenda = 0m;
+            for (int d = 0; d < datasVenda.Count; d++)
+            {
+                var val = porDiaVenda.TryGetValue(datasVenda[d], out var dv) && dv.TryGetValue(nome, out var vv) ? vv : 0m;
+                rowTotalVenda += val;
+                var cell = ws.Cell(excelRow, colVendaStart + d);
+                if (val > 0) { cell.Value = val; cell.Style.NumberFormat.Format = "#,##0.000"; }
+            }
+            if (datasVenda.Count > 0)
+            {
+                var cellRowTotalVenda = ws.Cell(excelRow, colVendaStart + datasVenda.Count);
+                if (rowTotalVenda > 0) { cellRowTotalVenda.Value = rowTotalVenda; cellRowTotalVenda.Style.NumberFormat.Format = "#,##0.000"; cellRowTotalVenda.Style.Font.Bold = true; }
+                cellRowTotalVenda.Style.Fill.BackgroundColor = vendaTotalColFill;
+            }
+
+            // — coluna Estoque Atual —
+            decimal estoqueAtual = Math.Max(0m, rowTotal - rowTotalVenda);
+            var cellEstoqueAtual = ws.Cell(excelRow, colEstoqueAtual);
+            if (estoqueAtual > 0) { cellEstoqueAtual.Value = estoqueAtual; cellEstoqueAtual.Style.NumberFormat.Format = "#,##0.000"; cellEstoqueAtual.Style.Font.Bold = true; }
+            cellEstoqueAtual.Style.Fill.BackgroundColor = estoqueCellFill;
+
             excelRow++;
         }
 
@@ -138,8 +227,9 @@ public static class RelatorioExcelService
 
         if (extrasExistem)
         {
-            // Linha separadora
-            var sepRange = ws.Range(excelRow, 1, excelRow, colOffset + datas.Count);
+            // Linha separadora — estende até a coluna Estoque Atual
+            int lastCol = colEstoqueAtual;
+            var sepRange = ws.Range(excelRow, 1, excelRow, lastCol);
             sepRange.Style.Fill.BackgroundColor = XLColor.FromHtml("#F3E5F5");
             ws.Cell(excelRow, 1).Value = "── Outros itens ──";
             ws.Cell(excelRow, 1).Style.Font.Italic = true;
@@ -150,7 +240,7 @@ public static class RelatorioExcelService
                 EscreverLinhaItem(nome, isExtra: true);
         }
 
-        // ── Linha TOTAL (soma por coluna) ────────────────────────────────────
+        // ── Linha TOTAL pesagem (soma por coluna) ─────────────────────────────
         int totalRow = excelRow;
 
         var cellTotalLabel = ws.Cell(totalRow, 1);
@@ -179,18 +269,58 @@ public static class RelatorioExcelService
         cellGrandTotal.Style.Font.Bold = true;
         cellGrandTotal.Style.Fill.BackgroundColor = XLColor.FromHtml("#C8E6C9");
 
-        // ── Bordas em toda a tabela ───────────────────────────────────────────
-        var tableRange = ws.Range(1, 1, totalRow, colOffset + datas.Count);
-        tableRange.Style.Border.OutsideBorder     = XLBorderStyleValues.Thin;
+        // ── Linha TOTAL vendas (soma por coluna de venda) ─────────────────────
+        if (datasVenda.Count > 0)
+        {
+            decimal grandTotalVenda = 0m;
+            for (int d = 0; d < datasVenda.Count; d++)
+            {
+                var colTotal = porDiaVenda.TryGetValue(datasVenda[d], out var dv)
+                    ? dv.Values.Sum()
+                    : 0m;
+                grandTotalVenda += colTotal;
+
+                var cell = ws.Cell(totalRow, colVendaStart + d);
+                cell.Value = colTotal;
+                cell.Style.NumberFormat.Format = "#,##0.000";
+                cell.Style.Font.Bold = true;
+                cell.Style.Fill.BackgroundColor = vendaTotalColFill;
+            }
+
+            var cellGrandTotalVenda = ws.Cell(totalRow, colVendaStart + datasVenda.Count);
+            cellGrandTotalVenda.Value = grandTotalVenda;
+            cellGrandTotalVenda.Style.NumberFormat.Format = "#,##0.000";
+            cellGrandTotalVenda.Style.Font.Bold = true;
+            cellGrandTotalVenda.Style.Fill.BackgroundColor = vendaGrandTotalFill;
+        }
+
+        // ── Linha TOTAL estoque atual ─────────────────────────────────────────
+        decimal grandTotalEstoqueAtual = Math.Max(0m, grandTotal - (datasVenda.Count > 0 ? porDiaVenda.Values.SelectMany(d => d.Values).Sum() : 0m));
+        var cellGrandEstoque = ws.Cell(totalRow, colEstoqueAtual);
+        cellGrandEstoque.Value = grandTotalEstoqueAtual;
+        cellGrandEstoque.Style.NumberFormat.Format = "#,##0.000";
+        cellGrandEstoque.Style.Font.Bold = true;
+        cellGrandEstoque.Style.Fill.BackgroundColor = estoqueGrandTotalFill;
+
+        // ── Bordas em toda a tabela (pesagens + vendas + estoque) ─────────────
+        int lastTableCol = colEstoqueAtual;
+        var tableRange = ws.Range(1, 1, totalRow, lastTableCol);
+        tableRange.Style.Border.OutsideBorder      = XLBorderStyleValues.Thin;
         tableRange.Style.Border.OutsideBorderColor = borderColor;
-        tableRange.Style.Border.InsideBorder      = XLBorderStyleValues.Hair;
+        tableRange.Style.Border.InsideBorder       = XLBorderStyleValues.Hair;
         tableRange.Style.Border.InsideBorderColor  = borderColor;
 
-        // ── Ajuste automático de largura de colunas ───────────────────────────
+        // ── Ajuste de largura de colunas ──────────────────────────────────────
         ws.Column(1).Width = 38;
         for (int d = 0; d < datas.Count; d++)
             ws.Column(colOffset + d).Width = 14;
-        ws.Column(colOffset + datas.Count).Width = 14;
+        ws.Column(colOffset + datas.Count).Width = 14;   // TOTAL pesagem
+
+        for (int d = 0; d < datasVenda.Count; d++)
+            ws.Column(colVendaStart + d).Width = 14;
+        if (datasVenda.Count > 0)
+            ws.Column(colVendaStart + datasVenda.Count).Width = 16; // TOTAL VENDAS
+        ws.Column(colEstoqueAtual).Width = 16;                      // Estoque Atual
 
         // Congela cabeçalho e coluna de nome
         ws.SheetView.Freeze(1, 1);

--- a/ControleMateriais.Desktop/Services/RelatorioExcelService.cs
+++ b/ControleMateriais.Desktop/Services/RelatorioExcelService.cs
@@ -1,0 +1,237 @@
+using ClosedXML.Excel;
+using ControleMateriais.Desktop;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace ControleMateriais.Desktop.Services;
+
+public static class RelatorioExcelService
+{
+    private static readonly CultureInfo PtBR = CultureInfo.GetCultureInfo("pt-BR");
+
+    /// <summary>
+    /// Gera o Excel de pesagens por dia e salva em <paramref name="outputPath"/>.
+    /// </summary>
+    /// <param name="recibosDir">Diretório raiz dos recibos (ex: …/Recibos)</param>
+    /// <param name="outputPath">Caminho completo do .xlsx a salvar</param>
+    /// <param name="progresso">Callback opcional para reportar progresso (mensagem)</param>
+    public static void Gerar(string recibosDir, string outputPath, Action<string>? progresso = null)
+    {
+        // ── 1. Listar PDFs (ignora subpastas como Recibos_Venda) ─────────────
+        var pdfs = Directory.GetFiles(recibosDir, "*.pdf", SearchOption.TopDirectoryOnly)
+            .OrderBy(f => f)
+            .ToList();
+
+        // ── 2. Extrair dados de cada PDF ──────────────────────────────────────
+        // dataStr → {nomeItem → pesoTotal do dia}
+        var porDia = new Dictionary<string, Dictionary<string, decimal>>(StringComparer.OrdinalIgnoreCase);
+        // todos os nomes de itens extras encontrados
+        var extrasGlobal = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        int contador = 0;
+        foreach (var pdf in pdfs)
+        {
+            contador++;
+            var dataStr = ExtrairDataDoNome(pdf);
+            progresso?.Invoke($"Lendo {contador}/{pdfs.Count}: {Path.GetFileName(pdf)}");
+
+            Dictionary<string, decimal> itens;
+            try { itens = ReciboParserService.ExtrairPesos(pdf); }
+            catch { continue; }
+
+            if (!porDia.TryGetValue(dataStr, out var diaDict))
+            {
+                diaDict = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+                porDia[dataStr] = diaDict;
+            }
+
+            foreach (var kv in itens)
+            {
+                diaDict[kv.Key] = diaDict.TryGetValue(kv.Key, out var atual) ? atual + kv.Value : kv.Value;
+
+                if (!ItemCatalog.OrderedItems.Contains(kv.Key, StringComparer.OrdinalIgnoreCase))
+                    extrasGlobal.Add(kv.Key);
+            }
+        }
+
+        // ── 3. Ordenar datas (colunas) de mais antiga a mais recente ─────────
+        var datas = porDia.Keys
+            .OrderBy(d => ParseData(d))
+            .ToList();
+
+        // ── 4. Montar lista de linhas: catálogo + extras alfabético ───────────
+        var linhasItens = ItemCatalog.OrderedItems
+            .Concat(extrasGlobal.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+
+        // ── 5. Gerar Excel ────────────────────────────────────────────────────
+        progresso?.Invoke("Gerando Excel...");
+
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Pesagens por Dia");
+
+        // Estilo base
+        var headerFill  = XLColor.FromHtml("#2E7D32");
+        var headerFont  = XLColor.White;
+        var totalFill   = XLColor.FromHtml("#E8F5E9");
+        var extraFill   = XLColor.FromHtml("#FFF8E1");
+        var borderColor = XLColor.FromHtml("#BDBDBD");
+
+        int colOffset = 2; // coluna A = nome do item, dados a partir de B
+
+        // ── Cabeçalho linha 1: "Item" + datas + "TOTAL" ─────────────────────
+        var cellItem = ws.Cell(1, 1);
+        cellItem.Value = "Item";
+        EstiloHeader(cellItem, headerFill, headerFont);
+
+        for (int d = 0; d < datas.Count; d++)
+        {
+            var cell = ws.Cell(1, colOffset + d);
+            cell.Value = datas[d];
+            EstiloHeader(cell, headerFill, headerFont);
+        }
+
+        var cellTotal = ws.Cell(1, colOffset + datas.Count);
+        cellTotal.Value = "TOTAL";
+        EstiloHeader(cellTotal, XLColor.FromHtml("#1B5E20"), headerFont);
+
+        // ── Linhas de itens ───────────────────────────────────────────────────
+        var extrasExistem = extrasGlobal.Count > 0;
+        int excelRow = 2; // linha 1 = cabeçalho
+
+        // Itens do catálogo
+        var itensFixos = linhasItens
+            .Where(n => ItemCatalog.OrderedItems.Contains(n, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+        var itensExtras = linhasItens
+            .Where(n => !ItemCatalog.OrderedItems.Contains(n, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+
+        void EscreverLinhaItem(string nome, bool isExtra)
+        {
+            var cellNome = ws.Cell(excelRow, 1);
+            cellNome.Value = nome;
+            cellNome.Style.Font.Bold = !isExtra;
+            if (isExtra) cellNome.Style.Fill.BackgroundColor = extraFill;
+
+            decimal rowTotal = 0m;
+            for (int d = 0; d < datas.Count; d++)
+            {
+                var val = porDia.TryGetValue(datas[d], out var dd) && dd.TryGetValue(nome, out var v) ? v : 0m;
+                rowTotal += val;
+                var cell = ws.Cell(excelRow, colOffset + d);
+                if (val > 0) { cell.Value = val; cell.Style.NumberFormat.Format = "#,##0.000"; }
+                if (isExtra) cell.Style.Fill.BackgroundColor = extraFill;
+            }
+            var cellRowTotal = ws.Cell(excelRow, colOffset + datas.Count);
+            if (rowTotal > 0) { cellRowTotal.Value = rowTotal; cellRowTotal.Style.NumberFormat.Format = "#,##0.000"; cellRowTotal.Style.Font.Bold = true; }
+            cellRowTotal.Style.Fill.BackgroundColor = totalFill;
+            excelRow++;
+        }
+
+        foreach (var nome in itensFixos)
+            EscreverLinhaItem(nome, isExtra: false);
+
+        if (extrasExistem)
+        {
+            // Linha separadora
+            var sepRange = ws.Range(excelRow, 1, excelRow, colOffset + datas.Count);
+            sepRange.Style.Fill.BackgroundColor = XLColor.FromHtml("#F3E5F5");
+            ws.Cell(excelRow, 1).Value = "── Outros itens ──";
+            ws.Cell(excelRow, 1).Style.Font.Italic = true;
+            ws.Cell(excelRow, 1).Style.Font.FontColor = XLColor.FromHtml("#6A1B9A");
+            excelRow++;
+
+            foreach (var nome in itensExtras)
+                EscreverLinhaItem(nome, isExtra: true);
+        }
+
+        // ── Linha TOTAL (soma por coluna) ────────────────────────────────────
+        int totalRow = excelRow;
+
+        var cellTotalLabel = ws.Cell(totalRow, 1);
+        cellTotalLabel.Value = "TOTAL";
+        cellTotalLabel.Style.Font.Bold = true;
+        cellTotalLabel.Style.Fill.BackgroundColor = totalFill;
+
+        decimal grandTotal = 0m;
+        for (int d = 0; d < datas.Count; d++)
+        {
+            var colTotal = porDia.TryGetValue(datas[d], out var dd)
+                ? dd.Values.Sum()
+                : 0m;
+            grandTotal += colTotal;
+
+            var cell = ws.Cell(totalRow, colOffset + d);
+            cell.Value = colTotal;
+            cell.Style.NumberFormat.Format = "#,##0.000";
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = totalFill;
+        }
+
+        var cellGrandTotal = ws.Cell(totalRow, colOffset + datas.Count);
+        cellGrandTotal.Value = grandTotal;
+        cellGrandTotal.Style.NumberFormat.Format = "#,##0.000";
+        cellGrandTotal.Style.Font.Bold = true;
+        cellGrandTotal.Style.Fill.BackgroundColor = XLColor.FromHtml("#C8E6C9");
+
+        // ── Bordas em toda a tabela ───────────────────────────────────────────
+        var tableRange = ws.Range(1, 1, totalRow, colOffset + datas.Count);
+        tableRange.Style.Border.OutsideBorder     = XLBorderStyleValues.Thin;
+        tableRange.Style.Border.OutsideBorderColor = borderColor;
+        tableRange.Style.Border.InsideBorder      = XLBorderStyleValues.Hair;
+        tableRange.Style.Border.InsideBorderColor  = borderColor;
+
+        // ── Ajuste automático de largura de colunas ───────────────────────────
+        ws.Column(1).Width = 38;
+        for (int d = 0; d < datas.Count; d++)
+            ws.Column(colOffset + d).Width = 14;
+        ws.Column(colOffset + datas.Count).Width = 14;
+
+        // Congela cabeçalho e coluna de nome
+        ws.SheetView.Freeze(1, 1);
+
+        wb.SaveAs(outputPath);
+        progresso?.Invoke($"Excel salvo: {Path.GetFileName(outputPath)}");
+    }
+
+    private static string ExtrairDataDoNome(string filePath)
+    {
+        var semExt = Path.GetFileNameWithoutExtension(filePath);
+
+        // Padrão _dd-MM-yyyy_HH-mm
+        var m1 = Regex.Match(semExt, @"_(\d{2}-\d{2}-\d{4})_\d{2}-\d{2}$");
+        if (m1.Success && DateTime.TryParseExact(m1.Groups[1].Value, "dd-MM-yyyy",
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt1))
+            return dt1.ToString("dd/MM/yyyy");
+
+        // Padrão _dd-MM-yyyy
+        var m2 = Regex.Match(semExt, @"_(\d{2}-\d{2}-\d{4})");
+        if (m2.Success && DateTime.TryParseExact(m2.Groups[1].Value, "dd-MM-yyyy",
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt2))
+            return dt2.ToString("dd/MM/yyyy");
+
+        // Fallback: data de modificação do arquivo
+        return File.GetLastWriteTime(filePath).ToString("dd/MM/yyyy");
+    }
+
+    private static DateTime ParseData(string dataStr)
+    {
+        if (DateTime.TryParseExact(dataStr, "dd/MM/yyyy",
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+            return dt;
+        return DateTime.MinValue;
+    }
+
+    private static void EstiloHeader(IXLCell cell, XLColor bgColor, XLColor fontColor)
+    {
+        cell.Style.Fill.BackgroundColor = bgColor;
+        cell.Style.Font.FontColor       = fontColor;
+        cell.Style.Font.Bold            = true;
+        cell.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+    }
+}

--- a/ControleMateriais.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/MainWindowViewModel.cs
@@ -591,6 +591,10 @@ public class MainWindowViewModel : ViewModelBase
             var conteudo = jsonObj.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
             await System.IO.File.WriteAllTextAsync(jsonPath, conteudo);
 
+            // Valida que o JSON foi criado corretamente
+            if (!System.IO.File.Exists(jsonPath) || new System.IO.FileInfo(jsonPath).Length == 0)
+                throw new InvalidOperationException($"Falha ao criar o arquivo JSON do recibo no banco de dados: {jsonPath}");
+
             // Soma diretamente no estoque.json
             AtualizarStatusTela("Atualizando estoque...");
             var totaisEstoque = EstoqueViewModel.LerEstoque(RootDir);

--- a/ControleMateriais.Desktop/ViewModels/PesagensViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/PesagensViewModel.cs
@@ -265,7 +265,8 @@ public class PesagensViewModel : ViewModelBase
     public ICommand AbrirPdfCommand           { get; }
     public ICommand DeletarReciboCommand      { get; }
     public ICommand DeletarPesagemCommand     { get; }
-    public ICommand ExportarExcelCommand      { get; }
+    public ICommand ExportarExcelCommand        { get; }
+    public ICommand ReconstruirBancoDadosCommand { get; }
 
     public Func<Task>?                          SolicitarConfiguracaoGitHubCallback { get; set; }
     public Action<PesagemItem>?                 AbrirReciboCallback { get; set; }
@@ -273,6 +274,7 @@ public class PesagensViewModel : ViewModelBase
     public Func<ReciboItem, Task>?              ConfirmarDeletarReciboCallback { get; set; }
     public Func<PesagemItem, Task>?             ConfirmarDeletarPesagemCallback { get; set; }
     public Action?                              NovoReciboPublicadoCallback { get; set; }
+    public Func<string, Task<bool>>?            ConfirmarReconstruirBancoDadosCallback { get; set; }
 
     public PesagensViewModel(Action voltarCallback, string rootDir)
     {
@@ -300,7 +302,8 @@ public class PesagensViewModel : ViewModelBase
         {
             if (item is not null) _ = ConfirmarDeletarPesagemCallback?.Invoke(item);
         });
-        ExportarExcelCommand = new DelegateCommand(() => _ = ExportarExcelAsync());
+        ExportarExcelCommand        = new DelegateCommand(() => _ = ExportarExcelAsync());
+        ReconstruirBancoDadosCommand = new DelegateCommand(() => _ = ReconstruirBancoDadosAsync());
     }
 
     public void CarregarPesagens()
@@ -711,6 +714,55 @@ public class PesagensViewModel : ViewModelBase
         finally
         {
             ExportandoExcel = false;
+        }
+    }
+
+    private bool _reconstruindoBancoDados;
+    public bool ReconstruindoBancoDados
+    {
+        get => _reconstruindoBancoDados;
+        private set { if (value != _reconstruindoBancoDados) { _reconstruindoBancoDados = value; OnPropertyChanged(); } }
+    }
+
+    private async Task ReconstruirBancoDadosAsync()
+    {
+        if (ReconstruindoBancoDados) return;
+
+        if (ConfirmarReconstruirBancoDadosCallback is not null)
+        {
+            var ok = await ConfirmarReconstruirBancoDadosCallback(
+                "Esta ação irá apagar todos os JSONs em banco-de-dados/ e recriá-los a partir dos PDFs de recibos.\n\n" +
+                "O estoque.json será recalculado somando todas as pesagens e subtraindo as vendas.\n\n" +
+                "Deseja continuar?");
+            if (!ok) return;
+        }
+
+        ReconstruindoBancoDados = true;
+        MostrarStatusRecibos("Reconstruindo banco de dados...", ok: true);
+
+        try
+        {
+            var bancoDadosDir = GitHubService.BancoDadosRepoDir(RootDir);
+            if (!Directory.Exists(bancoDadosDir))
+            {
+                MostrarStatusRecibos("Diretório banco-de-dados não encontrado.", ok: false);
+                return;
+            }
+
+            await Task.Run(() =>
+                ReconstruirBancoDadosService.Reconstruir(RootDir,
+                    msg => Avalonia.Threading.Dispatcher.UIThread.Post(
+                        () => MostrarStatusRecibos(msg, ok: true))));
+
+            MostrarStatusRecibos("Banco de dados reconstruído com sucesso!", ok: true);
+        }
+        catch (Exception ex)
+        {
+            MostrarStatusRecibos($"Erro ao reconstruir: {ex.Message}", ok: false);
+        }
+        finally
+        {
+            ReconstruindoBancoDados = false;
         }
     }
 }

--- a/ControleMateriais.Desktop/ViewModels/PesagensViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/PesagensViewModel.cs
@@ -1,3 +1,4 @@
+using Avalonia.Platform.Storage;
 using ControleMateriais.Desktop.Services;
 using System;
 using System.Collections.ObjectModel;
@@ -211,7 +212,7 @@ public class PesagensViewModel : ViewModelBase
                 (string.IsNullOrEmpty(nome) || r.NomeArquivo.Contains(nome, StringComparison.OrdinalIgnoreCase)) &&
                 (_filtroReciboMes == null ||
                  (r.DataCriacaoRaw.Year == _filtroReciboMes.Ano && r.DataCriacaoRaw.Month == _filtroReciboMes.Mes)))
-            .OrderBy(r => r.DataCriacaoRaw))
+            .OrderByDescending(r => r.DataCriacaoRaw))
         {
             RecibosVisiveis.Add(r);
         }
@@ -264,6 +265,7 @@ public class PesagensViewModel : ViewModelBase
     public ICommand AbrirPdfCommand           { get; }
     public ICommand DeletarReciboCommand      { get; }
     public ICommand DeletarPesagemCommand     { get; }
+    public ICommand ExportarExcelCommand      { get; }
 
     public Func<Task>?                          SolicitarConfiguracaoGitHubCallback { get; set; }
     public Action<PesagemItem>?                 AbrirReciboCallback { get; set; }
@@ -298,6 +300,7 @@ public class PesagensViewModel : ViewModelBase
         {
             if (item is not null) _ = ConfirmarDeletarPesagemCallback?.Invoke(item);
         });
+        ExportarExcelCommand = new DelegateCommand(() => _ = ExportarExcelAsync());
     }
 
     public void CarregarPesagens()
@@ -650,5 +653,64 @@ public class PesagensViewModel : ViewModelBase
     {
         StatusRecibos    = mensagem;
         StatusRecibosOk  = ok;
+    }
+
+    private bool _exportandoExcel;
+    public bool ExportandoExcel
+    {
+        get => _exportandoExcel;
+        private set { if (value != _exportandoExcel) { _exportandoExcel = value; OnPropertyChanged(); } }
+    }
+
+    private async Task ExportarExcelAsync()
+    {
+        if (ExportandoExcel) return;
+        ExportandoExcel = true;
+        MostrarStatusRecibos("Preparando exportação...", ok: true);
+
+        try
+        {
+            var recibosDir = GitHubService.RecibosRepoDir(RootDir);
+            if (!Directory.Exists(recibosDir))
+            {
+                MostrarStatusRecibos("Diretório de recibos não encontrado. Sincronize primeiro.", ok: false);
+                return;
+            }
+
+            var topLevel = (Avalonia.Application.Current?.ApplicationLifetime as
+                            Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+            if (topLevel is null) return;
+
+            var suggestedName = $"Relatorio_Pesagens_{DateTime.Now:dd-MM-yyyy}.xlsx";
+            var file = await topLevel.StorageProvider.SaveFilePickerAsync(
+                new Avalonia.Platform.Storage.FilePickerSaveOptions
+                {
+                    Title             = "Salvar relatório Excel",
+                    SuggestedFileName = suggestedName,
+                    FileTypeChoices   = new[]
+                    {
+                        new Avalonia.Platform.Storage.FilePickerFileType("Excel")
+                            { Patterns = new[] { "*.xlsx" } }
+                    }
+                });
+
+            var outputPath = file?.TryGetLocalPath();
+            if (string.IsNullOrWhiteSpace(outputPath)) { MostrarStatusRecibos(string.Empty, ok: true); return; }
+
+            await Task.Run(() =>
+                RelatorioExcelService.Gerar(recibosDir, outputPath,
+                    msg => Avalonia.Threading.Dispatcher.UIThread.Post(
+                        () => MostrarStatusRecibos(msg, ok: true))));
+
+            MostrarStatusRecibos($"Excel exportado com sucesso.", ok: true);
+        }
+        catch (Exception ex)
+        {
+            MostrarStatusRecibos($"Erro ao exportar Excel: {ex.Message}", ok: false);
+        }
+        finally
+        {
+            ExportandoExcel = false;
+        }
     }
 }

--- a/ControleMateriais.Desktop/Views/HomeView.axaml
+++ b/ControleMateriais.Desktop/Views/HomeView.axaml
@@ -77,7 +77,14 @@
                  HorizontalAlignment="Center"
                  Foreground="{DynamicResource Brush.Primary}"
                  LetterSpacing="1"
-                 Margin="0,0,0,44"/>
+                 Margin="0,0,0,6"/>
+
+      <!-- Versão -->
+      <TextBlock Text="V5.0.0"
+                 FontSize="13"
+                 HorizontalAlignment="Center"
+                 Foreground="White"
+                 Margin="0,0,0,36"/>
 
       <!-- Botões de navegação -->
       <StackPanel Orientation="Horizontal"

--- a/ControleMateriais.Desktop/Views/PesagensView.axaml
+++ b/ControleMateriais.Desktop/Views/PesagensView.axaml
@@ -233,11 +233,16 @@
                            VerticalAlignment="Center"
                            Foreground="{Binding StatusRecibosOk, Converter={StaticResource SyncStatusBrush}}"/>
               </StackPanel>
-              <Button Grid.Column="1"
-                      Content="⟳ Sincronizar"
-                      IsEnabled="{Binding !SincronizandoRecibos}"
-                      Command="{Binding SincronizarRecibosCommand}"
-                      ToolTip.Tip="Sincronizar recibos com repositório GitHub"/>
+              <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6">
+                <Button Content="📊 Exportar Excel"
+                        IsEnabled="{Binding !ExportandoExcel}"
+                        Command="{Binding ExportarExcelCommand}"
+                        ToolTip.Tip="Gerar planilha Excel com pesagens por dia de todos os recibos"/>
+                <Button Content="⟳ Sincronizar"
+                        IsEnabled="{Binding !SincronizandoRecibos}"
+                        Command="{Binding SincronizarRecibosCommand}"
+                        ToolTip.Tip="Sincronizar recibos com repositório GitHub"/>
+              </StackPanel>
             </Grid>
 
             <!-- Última sincronização -->

--- a/ControleMateriais.Desktop/Views/PesagensView.axaml
+++ b/ControleMateriais.Desktop/Views/PesagensView.axaml
@@ -238,6 +238,12 @@
                         IsEnabled="{Binding !ExportandoExcel}"
                         Command="{Binding ExportarExcelCommand}"
                         ToolTip.Tip="Gerar planilha Excel com pesagens por dia de todos os recibos"/>
+                <Button Content="🔄 Reconstruir Banco"
+                        IsEnabled="{Binding !ReconstruindoBancoDados}"
+                        Command="{Binding ReconstruirBancoDadosCommand}"
+                        Background="#E65100"
+                        Foreground="White"
+                        ToolTip.Tip="Apaga todos os JSONs e reconstrói o banco-de-dados a partir dos PDFs de recibos"/>
                 <Button Content="⟳ Sincronizar"
                         IsEnabled="{Binding !SincronizandoRecibos}"
                         Command="{Binding SincronizarRecibosCommand}"

--- a/ControleMateriais.Desktop/Views/PesagensView.axaml
+++ b/ControleMateriais.Desktop/Views/PesagensView.axaml
@@ -213,10 +213,10 @@
              ABA 2: RECIBOS
              ══════════════════════════════════════════════════ -->
         <TabItem Header="Recibos">
-          <Grid RowDefinitions="Auto,Auto,*">
+          <Grid RowDefinitions="Auto,Auto,Auto,*">
 
-            <!-- Barra: filtros + Sincronizar -->
-            <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,8,0,6">
+            <!-- Barra: filtros + botões -->
+            <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,8,0,4">
               <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                 <TextBox Text="{Binding FiltroReciboNome, Mode=TwoWay}"
                          Watermark="Buscar por nome..."
@@ -227,11 +227,6 @@
                           Width="150" FontSize="12"
                           VerticalAlignment="Center"
                           ToolTip.Tip="Filtrar por mês"/>
-                <TextBlock Text="{Binding StatusRecibos}"
-                           IsVisible="{Binding StatusRecibosVisivel}"
-                           FontSize="12"
-                           VerticalAlignment="Center"
-                           Foreground="{Binding StatusRecibosOk, Converter={StaticResource SyncStatusBrush}}"/>
               </StackPanel>
               <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6">
                 <Button Content="📊 Exportar Excel"
@@ -251,8 +246,17 @@
               </StackPanel>
             </Grid>
 
-            <!-- Última sincronização -->
+            <!-- Mensagem de status (sincronização / erros) -->
             <TextBlock Grid.Row="1"
+                       Text="{Binding StatusRecibos}"
+                       IsVisible="{Binding StatusRecibosVisivel}"
+                       HorizontalAlignment="Center"
+                       FontSize="12"
+                       Margin="0,2,0,2"
+                       Foreground="{Binding StatusRecibosOk, Converter={StaticResource SyncStatusBrush}}"/>
+
+            <!-- Última sincronização -->
+            <TextBlock Grid.Row="2"
                        Text="{Binding UltimaSincRecibos}"
                        IsVisible="{Binding UltimaSincRecibosVisivel}"
                        HorizontalAlignment="Center"
@@ -261,7 +265,7 @@
                        Margin="0,0,0,4"/>
 
             <!-- Corpo -->
-            <Grid Grid.Row="2">
+            <Grid Grid.Row="3">
 
               <!-- Sem repositório Recibos clonado -->
               <StackPanel IsVisible="{Binding !RecibosDirPresente}"

--- a/ControleMateriais.Desktop/Views/PesagensView.axaml.cs
+++ b/ControleMateriais.Desktop/Views/PesagensView.axaml.cs
@@ -27,6 +27,14 @@ public partial class PesagensView : UserControl
 
             vm.ConfirmarDeletarReciboCallback  = AbrirConfirmDeleteReciboAsync;
             vm.ConfirmarDeletarPesagemCallback = AbrirConfirmDeletePesagemAsync;
+            vm.ConfirmarReconstruirBancoDadosCallback = async msg =>
+            {
+                var owner = TopLevel.GetTopLevel(this) as Avalonia.Controls.Window;
+                if (owner is null) return false;
+                var dlg = new ConfirmDeleteDialog(msg);
+                await dlg.ShowDialog(owner);
+                return dlg.Confirmado;
+            };
 
             // Quando um novo recibo é publicado, reseta flag para re-sync na próxima abertura da aba
             vm.NovoReciboPublicadoCallback = () => _sincRecibosFeita = false;

--- a/Sprints/Release5.md
+++ b/Sprints/Release5.md
@@ -1,0 +1,189 @@
+# Release 5 — LFB Controle de Materiais
+
+## Visão Geral
+
+Expande o módulo de **Pesagens e Recibos** com três grandes adições: sistema completo de **exportação para Excel** com dados de pesagem e vendas por dia, **reconstrução do banco de dados** a partir dos PDFs existentes, e melhorias de robustez no formulário de venda. Também corrige a disposição visual da mensagem de status na aba de Recibos e adiciona validação de integridade do JSON gerado no fluxo de exportação de recibos.
+
+---
+
+## ✨ Features Implementadas
+
+### 📊 Exportação para Excel (`RelatorioExcelService` + `ReciboParserService`)
+
+Nova funcionalidade acessível pelo botão **📊 Exportar Excel** na aba de Recibos:
+
+- Lê todos os PDFs de pesagem em `Recibos/` (raiz, ignora subpastas).
+- Lê todos os PDFs de venda em `Recibos/Recibos_Venda/`.
+- Extrai pesos por item de cada PDF usando o novo `ReciboParserService.ExtrairPesos`.
+- Gera planilha `.xlsx` com três blocos de colunas:
+
+| Bloco | Cor | Conteúdo |
+|-------|-----|----------|
+| **Pesagens por dia** | Verde (`#2E7D32`) | Uma coluna por data + coluna **TOTAL** |
+| **Vendas por dia** | Laranja (`#E65100` / `#BF360C`) | Uma coluna por data de venda + coluna **TOTAL VENDAS** |
+| **Estoque Atual** | Azul (`#0D47A1`) | `TOTAL pesagem − TOTAL VENDAS` por item |
+
+**Detalhes da planilha:**
+- Linha de rodapé **TOTAL** com soma por coluna (verde / laranja / azul).
+- Itens extras (fora do catálogo) exibidos em seção separada com linha divisória roxa.
+- Coluna do item com largura 38; colunas de data com largura 14; colunas totais com largura 16.
+- Cabeçalho e coluna de nomes congelados (`Freeze(1,1)`).
+- Bordas finas em toda a tabela.
+- Compatível com zero vendas: blocos laranja e azul omitidos automaticamente.
+
+---
+
+### 🔍 Extração de Pesos de PDF (`ReciboParserService`)
+
+Novo serviço estático responsável por parsear PDFs de recibos:
+
+- Extrai texto do PDF usando **iText7**.
+- Identifica itens pelo **catálogo** (`ItemCatalog.OrderedItems`) com suporte a aliases.
+- Lida com itens cujo peso aparece na mesma linha ou nas duas linhas seguintes.
+- Normaliza texto (acentos, maiúsculas, espaços entre dígitos por OCR).
+- Detecta e acumula **itens extras** (fora do catálogo) como segunda passagem.
+- Retorna `Dictionary<string, decimal>` com nome → peso em kg.
+
+---
+
+### 🔄 Reconstrução do Banco de Dados (`ReconstruirBancoDadosService`)
+
+Novo serviço acessível pelo botão **🔄 Reconstruir Banco** na aba de Recibos:
+
+- Apaga todos os JSONs existentes em `banco-de-dados/`.
+- Processa cada PDF de pesagem → gera o `.json` correspondente com os pesos extraídos.
+- Acumula totais de pesagem em memória.
+- Subtrai os pesos de cada PDF de venda (`Recibos_Venda/`) do total acumulado.
+- Grava `estoque.json` com o saldo final recalculado.
+- Progresso reportado em tempo real na UI via callback `Action<string>`.
+
+**Botão na UI:**
+- Fundo vermelho escuro (`#E65100`) + texto branco para destacar ação destrutiva.
+- Desabilitado durante execução (`IsEnabled="{Binding !ReconstruindoBancoDados}"`).
+- Tooltip explicativo sobre o comportamento de reconstrução.
+
+---
+
+### 📋 Melhorias no Formulário de Venda (`VendaView` / `VendaViewModel`)
+
+Campos adicionais e correções no fluxo de registro de venda:
+
+- Campos obrigatórios anteriormente ausentes adicionados ao formulário.
+- Layout da `VendaView.axaml` reorganizado para melhor usabilidade.
+- `VendaViewModel` expandido com validações e bindings faltantes.
+
+---
+
+### 🛡️ Validação de Integridade do JSON de Recibo (`MainWindowViewModel`)
+
+Após gravar o JSON do recibo no banco de dados:
+
+```csharp
+if (!File.Exists(jsonPath) || new FileInfo(jsonPath).Length == 0)
+    throw new InvalidOperationException(
+        $"Falha ao criar o arquivo JSON do recibo no banco de dados: {jsonPath}");
+```
+
+Garante que falhas silenciosas de I/O são detectadas imediatamente e exibidas ao usuário, prevenindo inconsistências no estoque.
+
+---
+
+### 🖥️ Versão exibida na tela inicial (`HomeView`)
+
+Label **V5.0.0** adicionado abaixo do título "LFB RECICLAGEM ELETRÔNICA":
+
+- Fonte 13px, cor branca, centralizado.
+- Permite identificar visualmente a versão em execução sem abrir configurações.
+
+---
+
+### 🗂️ Layout — Mensagem de Status na Aba de Recibos (`PesagensView`)
+
+A área de mensagem de sincronização/erros foi movida para uma linha dedicada acima do conteúdo principal:
+
+- Grid da aba Recibos reorganizado de 3 para 4 linhas:
+  - **Row 0** — barra de filtros + botões de ação
+  - **Row 1** — mensagem de status (`StatusRecibos`)
+  - **Row 2** — última sincronização (`UltimaSincRecibos`)
+  - **Row 3** — lista de recibos
+- Evita sobreposição da mensagem com os botões de ação.
+
+---
+
+## 🔧 Detalhes Técnicos
+
+### Novos Arquivos
+
+```
+ControleMateriais.Desktop/
+├── Services/
+│   ├── ReciboParserService.cs          — extração de pesos de PDFs (iText7)
+│   ├── RelatorioExcelService.cs        — geração do Excel (ClosedXML)
+│   └── ReconstruirBancoDadosService.cs — reconstrução completa do banco de dados
+```
+
+### Arquivos Modificados
+
+```
+ControleMateriais.Desktop/
+├── ViewModels/
+│   ├── PesagensViewModel.cs            — ExportarExcelCommand, ReconstruirBancoDadosCommand,
+│   │                                     ReconstruindoBancoDados, ExportandoExcel
+│   └── MainWindowViewModel.cs          — validação de integridade do JSON + ajuste de layout
+├── Views/
+│   ├── PesagensView.axaml              — botões Exportar Excel e Reconstruir Banco,
+│   │                                     layout de 4 linhas na aba Recibos
+│   ├── VendaView.axaml                 — campos adicionais no formulário de venda
+│   └── HomeView.axaml                  — label V5.0.0 abaixo do título
+├── Services/
+│   └── RelatorioExcelService.cs        — bloco de vendas + coluna Estoque Atual
+├── ControleMateriais.Desktop.csproj    — dependência ClosedXML adicionada
+```
+
+### Dependências Adicionadas
+
+| Pacote | Uso |
+|--------|-----|
+| `ClosedXML` | Geração da planilha `.xlsx` |
+
+### Estrutura do Excel Gerado
+
+```
+| Item (38px) | dd/MM/yyyy... | TOTAL | dd/MM/yyyy... | TOTAL VENDAS | Estoque Atual |
+|-------------|---------------|-------|---------------|--------------|---------------|
+|  (verde)    |   (verde)     |(verde)|   (laranja)   |   (laranja)  |    (azul)     |
+```
+
+### Fluxo — Exportar Excel
+
+```
+Aba Recibos → 📊 Exportar Excel
+  → selecionar caminho de saída (.xlsx)
+  → lê PDFs de pesagem em Recibos/*.pdf
+  → lê PDFs de venda em Recibos/Recibos_Venda/*.pdf
+  → extrai pesos por item via ReciboParserService
+  → agrega por data (porDia / porDiaVenda)
+  → gera planilha com 3 blocos (pesagem / venda / estoque atual)
+  → salva arquivo e exibe mensagem de sucesso
+```
+
+### Fluxo — Reconstruir Banco de Dados
+
+```
+Aba Recibos → 🔄 Reconstruir Banco
+  → apaga todos os JSONs em banco-de-dados/
+  → para cada PDF em Recibos/*.pdf:
+      → extrai pesos → grava <nome>.json
+      → acumula em totaisPesagem
+  → para cada PDF em Recibos/Recibos_Venda/*.pdf:
+      → subtrai pesos do totaisEstoque
+  → grava estoque.json com saldo final
+```
+
+---
+
+**Versão**: Release 5 (V5.0.0)  
+**Branch**: `Release/4.0`  
+**Data**: 2026-06-18  
+**Responsável**: Gabriel Stundner  
+**Repositório**: `lfbreciclagemeletronica/Controle-Materiais`


### PR DESCRIPTION
# Release 5 — LFB Controle de Materiais

## Visão Geral

Expande o módulo de **Pesagens e Recibos** com três grandes adições: sistema completo de **exportação para Excel** com dados de pesagem e vendas por dia, **reconstrução do banco de dados** a partir dos PDFs existentes, e melhorias de robustez no formulário de venda. Também corrige a disposição visual da mensagem de status na aba de Recibos e adiciona validação de integridade do JSON gerado no fluxo de exportação de recibos.

---

## ✨ Features Implementadas

### 📊 Exportação para Excel (`RelatorioExcelService` + `ReciboParserService`)

Nova funcionalidade acessível pelo botão **📊 Exportar Excel** na aba de Recibos:

- Lê todos os PDFs de pesagem em `Recibos/` (raiz, ignora subpastas).
- Lê todos os PDFs de venda em `Recibos/Recibos_Venda/`.
- Extrai pesos por item de cada PDF usando o novo `ReciboParserService.ExtrairPesos`.
- Gera planilha `.xlsx` com três blocos de colunas:

| Bloco | Cor | Conteúdo |
|-------|-----|----------|
| **Pesagens por dia** | Verde (`#2E7D32`) | Uma coluna por data + coluna **TOTAL** |
| **Vendas por dia** | Laranja (`#E65100` / `#BF360C`) | Uma coluna por data de venda + coluna **TOTAL VENDAS** |
| **Estoque Atual** | Azul (`#0D47A1`) | `TOTAL pesagem − TOTAL VENDAS` por item |

**Detalhes da planilha:**
- Linha de rodapé **TOTAL** com soma por coluna (verde / laranja / azul).
- Itens extras (fora do catálogo) exibidos em seção separada com linha divisória roxa.
- Coluna do item com largura 38; colunas de data com largura 14; colunas totais com largura 16.
- Cabeçalho e coluna de nomes congelados (`Freeze(1,1)`).
- Bordas finas em toda a tabela.
- Compatível com zero vendas: blocos laranja e azul omitidos automaticamente.

---

### 🔍 Extração de Pesos de PDF (`ReciboParserService`)

Novo serviço estático responsável por parsear PDFs de recibos:

- Extrai texto do PDF usando **iText7**.
- Identifica itens pelo **catálogo** (`ItemCatalog.OrderedItems`) com suporte a aliases.
- Lida com itens cujo peso aparece na mesma linha ou nas duas linhas seguintes.
- Normaliza texto (acentos, maiúsculas, espaços entre dígitos por OCR).
- Detecta e acumula **itens extras** (fora do catálogo) como segunda passagem.
- Retorna `Dictionary<string, decimal>` com nome → peso em kg.

---

### 🔄 Reconstrução do Banco de Dados (`ReconstruirBancoDadosService`)

Novo serviço acessível pelo botão **🔄 Reconstruir Banco** na aba de Recibos:

- Apaga todos os JSONs existentes em `banco-de-dados/`.
- Processa cada PDF de pesagem → gera o `.json` correspondente com os pesos extraídos.
- Acumula totais de pesagem em memória.
- Subtrai os pesos de cada PDF de venda (`Recibos_Venda/`) do total acumulado.
- Grava `estoque.json` com o saldo final recalculado.
- Progresso reportado em tempo real na UI via callback `Action<string>`.

**Botão na UI:**
- Fundo vermelho escuro (`#E65100`) + texto branco para destacar ação destrutiva.
- Desabilitado durante execução (`IsEnabled="{Binding !ReconstruindoBancoDados}"`).
- Tooltip explicativo sobre o comportamento de reconstrução.

---

### 📋 Melhorias no Formulário de Venda (`VendaView` / `VendaViewModel`)

Campos adicionais e correções no fluxo de registro de venda:

- Campos obrigatórios anteriormente ausentes adicionados ao formulário.
- Layout da `VendaView.axaml` reorganizado para melhor usabilidade.
- `VendaViewModel` expandido com validações e bindings faltantes.

---

### 🛡️ Validação de Integridade do JSON de Recibo (`MainWindowViewModel`)

Após gravar o JSON do recibo no banco de dados:

```csharp
if (!File.Exists(jsonPath) || new FileInfo(jsonPath).Length == 0)
    throw new InvalidOperationException(
        $"Falha ao criar o arquivo JSON do recibo no banco de dados: {jsonPath}");
```

Garante que falhas silenciosas de I/O são detectadas imediatamente e exibidas ao usuário, prevenindo inconsistências no estoque.

---

### 🖥️ Versão exibida na tela inicial (`HomeView`)

Label **V5.0.0** adicionado abaixo do título "LFB RECICLAGEM ELETRÔNICA":

- Fonte 13px, cor branca, centralizado.
- Permite identificar visualmente a versão em execução sem abrir configurações.

---

### 🗂️ Layout — Mensagem de Status na Aba de Recibos (`PesagensView`)

A área de mensagem de sincronização/erros foi movida para uma linha dedicada acima do conteúdo principal:

- Grid da aba Recibos reorganizado de 3 para 4 linhas:
  - **Row 0** — barra de filtros + botões de ação
  - **Row 1** — mensagem de status (`StatusRecibos`)
  - **Row 2** — última sincronização (`UltimaSincRecibos`)
  - **Row 3** — lista de recibos
- Evita sobreposição da mensagem com os botões de ação.

---

## 🔧 Detalhes Técnicos

### Novos Arquivos

```
ControleMateriais.Desktop/
├── Services/
│   ├── ReciboParserService.cs          — extração de pesos de PDFs (iText7)
│   ├── RelatorioExcelService.cs        — geração do Excel (ClosedXML)
│   └── ReconstruirBancoDadosService.cs — reconstrução completa do banco de dados
```

### Arquivos Modificados

```
ControleMateriais.Desktop/
├── ViewModels/
│   ├── PesagensViewModel.cs            — ExportarExcelCommand, ReconstruirBancoDadosCommand,
│   │                                     ReconstruindoBancoDados, ExportandoExcel
│   └── MainWindowViewModel.cs          — validação de integridade do JSON + ajuste de layout
├── Views/
│   ├── PesagensView.axaml              — botões Exportar Excel e Reconstruir Banco,
│   │                                     layout de 4 linhas na aba Recibos
│   ├── VendaView.axaml                 — campos adicionais no formulário de venda
│   └── HomeView.axaml                  — label V5.0.0 abaixo do título
├── Services/
│   └── RelatorioExcelService.cs        — bloco de vendas + coluna Estoque Atual
├── ControleMateriais.Desktop.csproj    — dependência ClosedXML adicionada
```

### Dependências Adicionadas

| Pacote | Uso |
|--------|-----|
| `ClosedXML` | Geração da planilha `.xlsx` |

### Estrutura do Excel Gerado

```
| Item (38px) | dd/MM/yyyy... | TOTAL | dd/MM/yyyy... | TOTAL VENDAS | Estoque Atual |
|-------------|---------------|-------|---------------|--------------|---------------|
|  (verde)    |   (verde)     |(verde)|   (laranja)   |   (laranja)  |    (azul)     |
```

### Fluxo — Exportar Excel

```
Aba Recibos → 📊 Exportar Excel
  → selecionar caminho de saída (.xlsx)
  → lê PDFs de pesagem em Recibos/*.pdf
  → lê PDFs de venda em Recibos/Recibos_Venda/*.pdf
  → extrai pesos por item via ReciboParserService
  → agrega por data (porDia / porDiaVenda)
  → gera planilha com 3 blocos (pesagem / venda / estoque atual)
  → salva arquivo e exibe mensagem de sucesso
```

### Fluxo — Reconstruir Banco de Dados

```
Aba Recibos → 🔄 Reconstruir Banco
  → apaga todos os JSONs em banco-de-dados/
  → para cada PDF em Recibos/*.pdf:
      → extrai pesos → grava <nome>.json
      → acumula em totaisPesagem
  → para cada PDF em Recibos/Recibos_Venda/*.pdf:
      → subtrai pesos do totaisEstoque
  → grava estoque.json com saldo final
```

---

**Versão**: Release 5 (V5.0.0)  
**Branch**: `Release/4.0`  
**Data**: 2026-06-18  
**Responsável**: Gabriel Stundner  
**Repositório**: `lfbreciclagemeletronica/Controle-Materiais`
