### PR TITLE
Release 5.1

### DIFF
--- a/ControleMateriais.Desktop/Services/GitHubService.cs
+++ b/ControleMateriais.Desktop/Services/GitHubService.cs
@@ -568,10 +568,17 @@ public static class GitHubService
     {
         if (!CredenciaisExistem(rootDir)) return;
         var creds   = CarregarCredenciais(rootDir)!;
+        if (string.IsNullOrWhiteSpace(creds.UrlRecibos)) return;
+
         var repoDir = RecibosRepoDir(rootDir);
         var gitDir  = Path.Combine(repoDir, ".git");
-        if (!Directory.Exists(gitDir)) return;
-        if (string.IsNullOrWhiteSpace(creds.UrlRecibos)) return;
+
+        // Garante que o repo está clonado antes de tentar publicar
+        if (!Directory.Exists(gitDir))
+        {
+            progresso?.Invoke("Clonando repositório de Recibos...");
+            await GarantirRecibosRepoAsync(rootDir, msg => progresso?.Invoke(msg));
+        }
 
         var remoteUrl = InjetarToken(creds.UrlRecibos, creds.Token);
         progresso?.Invoke("Configurando repositório...");
@@ -579,15 +586,30 @@ public static class GitHubService
         await RunAsync("git", $"config user.email \"{creds.GitEmail}\"", repoDir);
         await RunAsync("git", $"config user.name \"{creds.GitUsuario}\"", repoDir);
 
+        // Pull antes do push para evitar conflitos
+        await RunAsync("git", "fetch origin main", repoDir);
+        await RunAsync("git", "rebase origin/main", repoDir);
+
         var subDir  = Path.Combine(repoDir, "Recibos_Venda");
         Directory.CreateDirectory(subDir);
-        var destino = Path.Combine(subDir, Path.GetFileName(filePath));
-        if (!File.Exists(destino))
-            File.Copy(filePath, destino, overwrite: true);
 
-        var relPath = Path.Combine("Recibos_Venda", Path.GetFileName(filePath)).Replace('\\', '/');
-        progresso?.Invoke("Adicionando arquivo...");
-        await RunAsync("git", $"add \"{relPath}\"", repoDir);
+        // Copia PDF
+        var destPdf = Path.Combine(subDir, Path.GetFileName(filePath));
+        File.Copy(filePath, destPdf, overwrite: true);
+        var relPdf = Path.Combine("Recibos_Venda", Path.GetFileName(filePath)).Replace('\\', '/');
+
+        // Copia .meta.json se existir ao lado do PDF original
+        var metaOrigem  = filePath + ".meta.json";
+        var metaNome    = Path.GetFileName(filePath) + ".meta.json";
+        var relMeta     = Path.Combine("Recibos_Venda", metaNome).Replace('\\', '/');
+        if (File.Exists(metaOrigem))
+            File.Copy(metaOrigem, Path.Combine(subDir, metaNome), overwrite: true);
+
+        progresso?.Invoke("Adicionando arquivos...");
+        await RunAsync("git", $"add \"{relPdf}\"", repoDir);
+        if (File.Exists(metaOrigem))
+            await RunAsync("git", $"add \"{relMeta}\"", repoDir);
+
         progresso?.Invoke("Commitando...");
         var commit = await RunAsync("git", $"commit -m \"{mensagemCommit}\"", repoDir);
         if (commit.exitCode == 0)

--- a/ControleMateriais.Desktop/Services/ReciboParserService.cs
+++ b/ControleMateriais.Desktop/Services/ReciboParserService.cs
@@ -24,9 +24,10 @@ public static class ReciboParserService
         "cnpj", "impurezas"
     };
 
-    // Regex: número com 3 casas decimais no formato brasileiro (ex: 22,710 ou 1.234,567)
+    // Regex: número com 3 casas decimais — pt-BR (vírgula) OU invariant (ponto)
+    // Ex: 22,710 | 1.234,567 | 1.258 | 22.710
     private static readonly Regex _rePeso = new(
-        @"(?<!\d)([\d]{1,3}(?:\.\d{3})*,\d{3})(?!\d)|(?<!\d)(\d+,\d{3})(?!\d)",
+        @"(?<!\d)([\d]{1,3}(?:\.\d{3})*,\d{3})(?!\d)|(?<!\d)(\d+,\d{3})(?!\d)|(?<!\d)(\d+\.\d{3})(?!\d)",
         RegexOptions.Compiled);
 
     // Corrige artefato do iText: "2 2,710" → "22,710"
@@ -197,9 +198,20 @@ public static class ReciboParserService
         {
             var raw = m.Groups[g].Value.Trim();
             if (string.IsNullOrEmpty(raw)) continue;
-            raw = raw.Replace(".", "").Replace(",", ".");
-            if (decimal.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out var val))
-                return val;
+
+            // Formato pt-BR com vírgula decimal: "1.234,567" ou "22,710"
+            if (raw.Contains(','))
+            {
+                var ptbr = raw.Replace(".", "").Replace(",", ".");
+                if (decimal.TryParse(ptbr, NumberStyles.Any, CultureInfo.InvariantCulture, out var v1))
+                    return v1;
+            }
+            // Formato invariant com ponto decimal: "1.258" ou "22.710"
+            else if (raw.Contains('.'))
+            {
+                if (decimal.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out var v2))
+                    return v2;
+            }
         }
         return null;
     }

--- a/ControleMateriais.Desktop/Services/ReconstruirBancoDadosService.cs
+++ b/ControleMateriais.Desktop/Services/ReconstruirBancoDadosService.cs
@@ -20,6 +20,15 @@ public static class ReconstruirBancoDadosService
         var bancoDadosDir = GitHubService.BancoDadosRepoDir(rootDir);
         var recibosDir    = GitHubService.RecibosRepoDir(rootDir);
         var vendaDir      = Path.Combine(recibosDir, "Recibos_Venda");
+        var logPath       = Path.Combine(rootDir, "reconstruir-banco.log");
+
+        var logLines    = new System.Collections.Generic.List<string>();
+        var progressoOrig = progresso;
+        progresso = msg =>
+        {
+            logLines.Add($"[{DateTime.Now:HH:mm:ss}] {msg}");
+            progressoOrig?.Invoke(msg);
+        };
 
         // ── 1. Apagar todos os .json existentes em banco-de-dados/ ────────────
         progresso?.Invoke("Removendo JSONs antigos...");
@@ -34,8 +43,17 @@ public static class ReconstruirBancoDadosService
         }
 
         // ── 2. Processar cada PDF de pesagem → gerar JSON ────────────────────
+        // Exclui PDFs cujo nome também existe em Recibos_Venda/ (são recibos de venda na pasta errada)
+        var nomesVenda = Directory.Exists(vendaDir)
+            ? new HashSet<string>(
+                Directory.GetFiles(vendaDir, "*.pdf", SearchOption.TopDirectoryOnly)
+                         .Select(Path.GetFileName)!,
+                StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         var pdfs = Directory.Exists(recibosDir)
             ? Directory.GetFiles(recibosDir, "*.pdf", SearchOption.TopDirectoryOnly)
+                       .Where(f => !nomesVenda.Contains(Path.GetFileName(f)))
                        .OrderBy(f => f)
                        .ToList()
             : new List<string>();
@@ -98,12 +116,22 @@ public static class ReconstruirBancoDadosService
 
                 Dictionary<string, decimal> itensVenda;
                 try { itensVenda = ReciboParserService.ExtrairPesos(pdf); }
-                catch { continue; }
+                catch (Exception ex) { progresso?.Invoke($"  ERRO ao ler {Path.GetFileName(pdf)}: {ex.Message}"); continue; }
+
+                if (itensVenda.Count == 0)
+                {
+                    progresso?.Invoke($"  AVISO: {Path.GetFileName(pdf)} — nenhum item reconhecido pelo parser.");
+                    continue;
+                }
+
+                progresso?.Invoke($"  {Path.GetFileName(pdf)}: {itensVenda.Count} item(ns) — {string.Join(", ", itensVenda.Select(kv => $"{kv.Key}={kv.Value:N3}"))}");
 
                 foreach (var kv in itensVenda)
                 {
                     if (totaisEstoque.TryGetValue(kv.Key, out var atual))
                         totaisEstoque[kv.Key] = Math.Max(0m, atual - kv.Value);
+                    else
+                        progresso?.Invoke($"  AVISO: item \"{kv.Key}\" não encontrado no estoque de pesagem.");
                 }
             }
         }
@@ -120,6 +148,8 @@ public static class ReconstruirBancoDadosService
         EstoqueViewModel.GravarEstoque(rootDir, totaisEstoque);
 
         progresso?.Invoke($"Concluído. {gerados} JSONs + estoque.json gravados.");
+
+        try { File.WriteAllLines(logPath, logLines); } catch { }
     }
 
     private static string ExtrairDataDoNome(string filePath)

--- a/ControleMateriais.Desktop/ViewModels/EstoqueViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/EstoqueViewModel.cs
@@ -364,6 +364,11 @@ public class EstoqueViewModel : ViewModelBase
         Status = "Conectando ao repositório...";
         try
         {
+            // Sincroniza repositório Recibos (inclui Recibos_Venda/)
+            await GitHubService.GarantirRecibosRepoAsync(_rootDir, msg => Status = msg);
+            await GitHubService.SincronizarRecibosAsync(_rootDir, msg => Status = msg);
+
+            // Sincroniza repositório banco-de-dados
             await GitHubService.GarantirBancoDadosRepoAsync(_rootDir, msg => Status = msg);
             var novos = ProcessarNovosJsons();
             Status = novos > 0

--- a/ControleMateriais.Desktop/ViewModels/EstoqueViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/EstoqueViewModel.cs
@@ -87,6 +87,13 @@ public class EstoqueViewModel : ViewModelBase
         private set { if (value != _sincronizando) { _sincronizando = value; OnPropertyChanged(); } }
     }
 
+    private bool _atualizando;
+    public bool Atualizando
+    {
+        get => _atualizando;
+        private set { if (value != _atualizando) { _atualizando = value; OnPropertyChanged(); } }
+    }
+
     public ICommand SincronizarGitCommand { get; }
     public ICommand IrParaVendaCommand    { get; }
 
@@ -95,7 +102,7 @@ public class EstoqueViewModel : ViewModelBase
         _rootDir = rootDir;
         SincronizarGitCommand     = new DelegateCommand(() => _ = SincronizarGitAsync());
         IrParaVendaCommand        = new DelegateCommand(() => irParaVendaAction?.Invoke());
-        AtualizarCommand          = new DelegateCommand(Recarregar);
+        AtualizarCommand          = new DelegateCommand(() => _ = AtualizarAsync());
         AbrirReciboVendaCommand   = new DelegateCommand<ReciboVendaItem?>(AbrirReciboVenda);
         ExcluirReciboVendaCommand = new DelegateCommand<ReciboVendaItem?>(r => _ = ExcluirReciboVendaAsync(r));
     }
@@ -354,6 +361,32 @@ public class EstoqueViewModel : ViewModelBase
         }
 
         RecibosVendaVazia = RecibosVenda.Count == 0;
+    }
+
+    // ── Pull Recibos_Venda do GitHub + recarrega lista ────────────────────
+    private async Task AtualizarAsync()
+    {
+        if (Atualizando) return;
+        Atualizando = true;
+        Status = "Atualizando recibos de venda...";
+        try
+        {
+            if (GitHubService.CredenciaisExistem(_rootDir))
+            {
+                await GitHubService.GarantirRecibosRepoAsync(_rootDir, msg => Status = msg);
+                await GitHubService.SincronizarRecibosAsync(_rootDir, msg => Status = msg);
+            }
+            Recarregar();
+            Status = "Recibos de venda atualizados.";
+        }
+        catch (Exception ex)
+        {
+            Status = $"Erro ao atualizar: {ex.Message}";
+        }
+        finally
+        {
+            Atualizando = false;
+        }
     }
 
     // ── Pull Git + processa novos JSONs remotos ────────────────────────────

--- a/ControleMateriais.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/MainWindowViewModel.cs
@@ -318,8 +318,9 @@ public class MainWindowViewModel : ViewModelBase
         PesagensVM    = new PesagensViewModel(() => CurrentPage = AppPage.Home, RootDir);
         EstoqueVM     = new EstoqueViewModel(RootDir, () => { IsGerindoTabela = false; CurrentPage = AppPage.Venda; VendaVM.CarregarItensExtras(); });
         VendaVM       = new VendaViewModel(RootDir, () => { CurrentPage = AppPage.Estoque; EstoqueVM.Recarregar(); });
-        PesagensVM.AbrirReciboCallback      = AbrirReciboDetalhe;
-        PesagensVM.CriarNovoReciboCallback  = CriarNovoRecibo;
+        PesagensVM.AbrirReciboCallback        = AbrirReciboDetalhe;
+        PesagensVM.CriarNovoReciboCallback    = CriarNovoRecibo;
+        PesagensVM.EstoqueRecarregarCallback  = () => EstoqueVM.Recarregar();
 
         _ = CarregarPrecosNaInicializacaoAsync();
     }

--- a/ControleMateriais.Desktop/ViewModels/PesagensViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/PesagensViewModel.cs
@@ -275,6 +275,7 @@ public class PesagensViewModel : ViewModelBase
     public Func<PesagemItem, Task>?             ConfirmarDeletarPesagemCallback { get; set; }
     public Action?                              NovoReciboPublicadoCallback { get; set; }
     public Func<string, Task<bool>>?            ConfirmarReconstruirBancoDadosCallback { get; set; }
+    public Action?                              EstoqueRecarregarCallback { get; set; }
 
     public PesagensViewModel(Action voltarCallback, string rootDir)
     {
@@ -749,12 +750,23 @@ public class PesagensViewModel : ViewModelBase
                 return;
             }
 
+            // Sincroniza Recibos (incluindo Recibos_Venda/) antes de reconstruir
+            if (GitHubService.CredenciaisExistem(RootDir))
+            {
+                MostrarStatusRecibos("Sincronizando recibos de venda com GitHub...", ok: true);
+                await GitHubService.GarantirRecibosRepoAsync(RootDir,
+                    msg => Avalonia.Threading.Dispatcher.UIThread.Post(() => MostrarStatusRecibos(msg, ok: true)));
+                await GitHubService.SincronizarRecibosAsync(RootDir,
+                    msg => Avalonia.Threading.Dispatcher.UIThread.Post(() => MostrarStatusRecibos(msg, ok: true)));
+            }
+
             await Task.Run(() =>
                 ReconstruirBancoDadosService.Reconstruir(RootDir,
                     msg => Avalonia.Threading.Dispatcher.UIThread.Post(
                         () => MostrarStatusRecibos(msg, ok: true))));
 
             MostrarStatusRecibos("Banco de dados reconstruído com sucesso!", ok: true);
+            EstoqueRecarregarCallback?.Invoke();
         }
         catch (Exception ex)
         {

--- a/ControleMateriais.Desktop/ViewModels/VendaViewModel.cs
+++ b/ControleMateriais.Desktop/ViewModels/VendaViewModel.cs
@@ -469,7 +469,7 @@ public class VendaViewModel : ViewModelBase
                             table.Cell().Element(BCell).AlignCenter()
                                  .Text(it.Nome).FontSize(cellFontSize);
                             table.Cell().Element(BCell).AlignCenter()
-                                 .Text(it.PesoAtual.ToString("N3")).FontSize(cellFontSize);
+                                 .Text(it.PesoAtual.ToString("N3", ptBR)).FontSize(cellFontSize);
                         }
                     });
                 });

--- a/ControleMateriais.Desktop/Views/EstoqueView.axaml
+++ b/ControleMateriais.Desktop/Views/EstoqueView.axaml
@@ -120,6 +120,7 @@
                 <Button Grid.Column="4"
                         Content="&#x27F3; Atualizar"
                         Command="{Binding AtualizarCommand}"
+                        IsEnabled="{Binding !Atualizando}"
                         FontSize="12"/>
               </Grid>
             </Border>

--- a/ControleMateriais.Desktop/Views/HomeView.axaml
+++ b/ControleMateriais.Desktop/Views/HomeView.axaml
@@ -80,7 +80,7 @@
                  Margin="0,0,0,6"/>
 
       <!-- Versão -->
-      <TextBlock Text="V5.0.0"
+      <TextBlock Text="V5.0.1"
                  FontSize="13"
                  HorizontalAlignment="Center"
                  Foreground="White"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 **Sistema desktop completo para controle de pesagem, triagem, valoração e venda de materiais eletrônicos recicláveis.**  
 Registra pesagens, gera recibos em PDF, gerencia tabelas de preços, controla o estoque por material e registra vendas com recibo dedicado — tudo sincronizado automaticamente com o GitHub.
 
+> **Versão atual: V5.0.1**
+
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![Avalonia](https://img.shields.io/badge/Avalonia-UI-8A2BE2?style=flat-square)](https://avaloniaui.net/)
 [![Platform](https://img.shields.io/badge/Plataforma-Windows%20%7C%20Linux-0078D6?style=flat-square)]()
@@ -44,6 +46,8 @@ Registra pesagens, gera recibos em PDF, gerencia tabelas de preços, controla o 
   - [Registrar uma venda](#registrar-uma-venda)
   - [Recibo de Venda PDF](#recibo-de-venda-pdf)
   - [Aba Recibos de Venda](#aba-recibos-de-venda)
+- [Exportar Excel](#exportar-excel)
+- [Reconstruir Banco de Dados](#reconstruir-banco-de-dados)
 - [Publicar / Build](#publicar--build)
 - [Tecnologias](#tecnologias)
 
@@ -53,13 +57,15 @@ Registra pesagens, gera recibos em PDF, gerencia tabelas de preços, controla o 
 
 O **Controle de Materiais LFB** é um sistema desktop desenvolvido para a [LFB Reciclagem Eletrônica](https://github.com/lfbreciclagemeletronica) que automatiza o processo de pesagem, triagem e valoração de materiais eletrônicos recicláveis.
 
-O sistema é composto por cinco módulos integrados:
+O sistema é composto por sete módulos integrados:
 
 - **Calculadora de Pesos** — registra os materiais e pesos recebidos de um fornecedor, calcula o valor total usando a tabela de preços ativa e gera o recibo em PDF
 - **Sistema de Pesagens** — gerencia todas as pesagens geradas pelo aplicativo de balanças externo, exibindo status (pendente, concluído, falhou) e sincronizando com o GitHub
 - **Sistema de Recibos** — armazena e exibe todos os PDFs de recibos gerados, sincronizando com repositório GitHub dedicado
 - **Controle de Estoque** — consolida todas as pesagens do banco de dados em um estoque unificado por material, com sincronização Git
 - **Venda de Estoque** — registra saídas de estoque por venda, gera recibo PDF dedicado e atualiza o `estoque.json` automaticamente
+- **Exportar Excel** — gera planilha `.xlsx` com pesagens e vendas por dia e coluna de Estoque Atual calculada
+- **Reconstruir Banco** — reconstrói todo o `banco-de-dados/` a partir dos PDFs existentes, reprocessando pesagens e descontando vendas
 
 Toda a sincronização é feita via **Git** usando repositórios privados no GitHub da organização `lfbreciclagemeletronica`, sem necessidade de nenhuma outra infraestrutura.
 
@@ -76,7 +82,9 @@ Toda a sincronização é feita via **Git** usando repositórios privados no Git
 │   └── Cliente_24-04-2026_concluido.json ← pesagem concluída (renomeada automaticamente)
 ├── banco-de-dados/               ← Repositório git clonado (lfbreciclagemeletronica/banco-de-dados)
 │   ├── .git/
-│   └── estoque.json
+│   ├── estoque.json
+│   └── <NomeCliente>_<data>.json  ← JSON por pesagem concluída
+├── reconstruir-banco.log         ← Log gerado pelo Reconstruir Banco (diagnóstico)
 ├── Recibos/
 │   ├── .git/
 │   ├── *.pdf
@@ -606,8 +614,9 @@ O repositório `lfbreciclagemeletronica/Recibos` armazena todos os PDFs de recib
 | Repositório | URL | Conteúdo |
 |---|---|---|
 | `Pesagens` | `github.com/lfbreciclagemeletronica/Pesagens` | JSONs de pesagens (pendentes e concluídas) |
-| `Recibos` | `github.com/lfbreciclagemeletronica/Recibos` | PDFs de recibos gerados |
+| `Recibos` | `github.com/lfbreciclagemeletronica/Recibos` | PDFs de pesagem + subpasta `Recibos_Venda/` |
 | `TabelaPrecos` | `github.com/lfbreciclagemeletronica/TabelaPrecos` | JSONs de tabelas de preços |
+| `banco-de-dados` | `github.com/lfbreciclagemeletronica/banco-de-dados` | JSONs por pesagem + `estoque.json` consolidado |
 
 **Padrão de mensagens de commit:**
 
@@ -635,9 +644,10 @@ A tela **Controle de Estoque** é acessível pelo botão **📦 Estoque** na tel
 
 **Funcionalidades:**
 - Lista todos os materiais do catálogo com o total em kg acumulado.
-- Botão **⟳ Sincronizar** — pull do repositório `banco-de-dados` e push do `estoque.json` atualizado.
+- Botão **⟳ Sincronizar** — pull do repositório `banco-de-dados` e push do `estoque.json` atualizado. Também sincroniza `Recibos/Recibos_Venda/` antes de recarregar.
 - Botão **💰 Venda** — abre o módulo de venda de estoque.
 - **Aba Recibos de Venda** — lista todos os recibos de venda gerados.
+- Botão **⟳ Atualizar** (aba Recibos de Venda) — pull de `Recibos_Venda/` do GitHub antes de recarregar a lista.
 
 ---
 
@@ -714,6 +724,73 @@ Segunda aba do Controle de Estoque exibe todos os recibos de venda gerados.
 
 ---
 
+## Exportar Excel
+
+Acessível pelo botão **📊 Exportar Excel** na aba de Recibos (tela de Pesagens).
+
+<div align="center">
+
+<!-- Imagem do botão Exportar Excel na aba de Recibos -->
+
+</div>
+
+**O que é gerado:**
+
+| Bloco | Cor | Conteúdo |
+|-------|-----|----------|
+| **Pesagens por dia** | Verde | Uma coluna por data + coluna **TOTAL** |
+| **Vendas por dia** | Laranja | Uma coluna por data de venda + coluna **TOTAL VENDAS** |
+| **Estoque Atual** | Azul | `TOTAL pesagem − TOTAL VENDAS` por item |
+
+<div align="center">
+
+<!-- Imagem da planilha Excel gerada com os três blocos de colunas -->
+
+</div>
+
+**Detalhes:**
+- Lê todos os PDFs de pesagem em `Recibos/` (raiz).
+- Lê todos os PDFs de venda em `Recibos/Recibos_Venda/`.
+- Extrai pesos por item via `ReciboParserService` (iText7).
+- Linha de totais ao final em cada bloco.
+- Itens fora do catálogo exibidos em seção separada com linha divisória roxa.
+- Cabeçalho e coluna de nomes congelados.
+- Compatível com zero vendas: blocos laranja e azul omitidos automaticamente.
+
+---
+
+## Reconstruir Banco de Dados
+
+Acessível pelo botão **🔄 Reconstruir Banco** na aba de Recibos (tela de Pesagens).
+
+<div align="center">
+
+<!-- Imagem do botão Reconstruir Banco na aba de Recibos -->
+
+</div>
+
+> ⚠️ **Ação destrutiva** — apaga todos os JSONs em `banco-de-dados/` e recalcula do zero a partir dos PDFs.
+
+**Fluxo:**
+
+```
+1. Sincroniza Recibos/Recibos_Venda/ com o GitHub (pull)
+2. Apaga todos os .json em banco-de-dados/ (exceto .git/)
+3. Para cada PDF em Recibos/*.pdf (excluindo PDFs que também existem em Recibos_Venda/):
+   → extrai pesos via ReciboParserService
+   → grava <nome>.json em banco-de-dados/
+   → acumula em totaisPesagem
+4. Para cada PDF em Recibos/Recibos_Venda/*.pdf:
+   → subtrai pesos do totaisEstoque
+5. Grava estoque.json com o saldo final
+6. Atualiza a tela de Estoque automaticamente
+7. Grava log de diagnóstico em reconstruir-banco.log
+```
+
+**Após a reconstrução**, a tela de Controle de Estoque é atualizada automaticamente sem precisar navegar de volta.
+
+---
+
 ## Publicar / Build
 
 Para gerar os binários de distribuição (requer .NET SDK instalado):
@@ -758,6 +835,7 @@ powershell -ExecutionPolicy Bypass -File generate-icon.ps1
 | [Avalonia UI](https://avaloniaui.net/) | 11 | Framework de UI multiplataforma (MVVM) |
 | [QuestPDF](https://www.questpdf.com/) | latest | Geração de recibos e listas em PDF |
 | [iText7](https://itextpdf.com/) | latest | Extração de texto de PDFs importados |
+| [ClosedXML](https://github.com/ClosedXML/ClosedXML) | latest | Geração de planilhas `.xlsx` |
 | Git | — | Controle de versão e sincronização com GitHub |
 
 ---

--- a/Sprints/Release5-1.md
+++ b/Sprints/Release5-1.md
@@ -1,0 +1,104 @@
+# Release 5.0.1 — LFB Controle de Materiais
+
+## Visão Geral
+
+Patch de correções críticas do **Reconstruir Banco de Dados** e sincronização do estoque. Corrige a subtração das vendas que não estava sendo aplicada ao estoque exibido, elimina contagem duplicada de PDFs de venda que estavam na raiz do repositório e garante que a tela de Estoque atualiza automaticamente após a reconstrução.
+
+---
+
+## 🐛 Correções
+
+### 1. Tela de Estoque não atualizava após Reconstruir Banco
+
+**Causa:** `EstoqueViewModel.Recarregar()` só era chamado quando o `DataContext` da view era atribuído pela primeira vez (ao navegar pela primeira vez para a tela). Como `EstoqueVM` é uma instância única, reconstruir o banco em `PesagensViewModel` gravava o novo `estoque.json` no disco, mas a tela de Estoque continuava exibindo os dados antigos em memória.
+
+**Correção:**
+- Adicionado `EstoqueRecarregarCallback` em `PesagensViewModel`.
+- Chamado ao final de `ReconstruirBancoDadosAsync` com sucesso.
+- Conectado em `MainWindowViewModel`:
+  ```csharp
+  PesagensVM.EstoqueRecarregarCallback = () => EstoqueVM.Recarregar();
+  ```
+
+**Arquivos alterados:**
+- `ViewModels/PesagensViewModel.cs`
+- `ViewModels/MainWindowViewModel.cs`
+
+---
+
+### 2. PDF de venda na raiz de `Recibos/` era contado como pesagem
+
+**Causa:** O arquivo `ESTOQUE_FINAL_29-05-2026.pdf` (e potencialmente outros) existia tanto em `Recibos/` (raiz) quanto em `Recibos/Recibos_Venda/`. O `Reconstruir` processava todos os PDFs da raiz como pesagens — inflando o total — e depois o mesmo arquivo era subtraído como venda, gerando inconsistência.
+
+**Correção:** Antes de listar os PDFs de pesagem, o `ReconstruirBancoDadosService` agora constrói um `HashSet` com os nomes de arquivos presentes em `Recibos_Venda/` e **exclui** da fase de pesagem qualquer PDF cujo nome coincida:
+
+```csharp
+var nomesVenda = new HashSet<string>(
+    Directory.GetFiles(vendaDir, "*.pdf").Select(Path.GetFileName)!,
+    StringComparer.OrdinalIgnoreCase);
+
+var pdfs = Directory.GetFiles(recibosDir, "*.pdf", SearchOption.TopDirectoryOnly)
+    .Where(f => !nomesVenda.Contains(Path.GetFileName(f)))
+    ...
+```
+
+**Arquivos alterados:**
+- `Services/ReconstruirBancoDadosService.cs`
+
+---
+
+### 3. Parser de pesos (`ReciboParserService`) não reconhecia ponto decimal
+
+**Causa:** PDFs de venda gerados antes da correção de cultura (V5.0.0) usavam ponto como separador decimal (ex: `19.129`). O regex `_rePeso` só reconhecia vírgula (ex: `19,129`).
+
+**Correção:**
+- Regex estendido com terceiro grupo `(\d+\.\d{3})` para capturar formato invariant.
+- `ExtrairPrimeiroPeso` adaptado para distinguir os dois formatos:
+  - Com vírgula → trata como pt-BR (`1.234,567` → `1234.567`)
+  - Com ponto sem vírgula → trata como invariant (`1.258` → parse direto)
+
+**Arquivos alterados:**
+- `Services/ReciboParserService.cs`
+
+---
+
+### 4. Log de diagnóstico gravado em disco após Reconstruir Banco
+
+Para facilitar diagnóstico de problemas futuros, o `ReconstruirBancoDadosService` agora grava um arquivo de log completo em:
+
+```
+~/Downloads/ControleMateriaisLFB/reconstruir-banco.log
+```
+
+O log contém timestamp, nome de cada PDF processado, itens extraídos e avisos de itens não reconhecidos ou não encontrados no estoque.
+
+---
+
+### 5. Versão atualizada para V5.0.1
+
+Label na tela inicial (`HomeView`) atualizado de `V5.0.0` para `V5.0.1`.
+
+---
+
+## 🔧 Arquivos Modificados
+
+```
+ControleMateriais.Desktop/
+├── ViewModels/
+│   ├── PesagensViewModel.cs        — EstoqueRecarregarCallback declarado e invocado
+│   └── MainWindowViewModel.cs      — EstoqueRecarregarCallback conectado ao EstoqueVM
+├── Services/
+│   ├── ReconstruirBancoDadosService.cs — exclusão de PDFs de venda da fase de pesagem,
+│   │                                     logging detalhado em disco
+│   └── ReciboParserService.cs      — regex e parser adaptados para ponto decimal
+└── Views/
+    └── HomeView.axaml              — versão V5.0.1
+```
+
+---
+
+**Versão**: Release 5.0.1  
+**Branch**: `Release/4.0`  
+**Data**: 2026-06-19  
+**Responsável**: Gabriel Stundner  
+**Repositório**: `lfbreciclagemeletronica/Controle-Materiais`


### PR DESCRIPTION
# Release 5.0.1 — LFB Controle de Materiais

## Visão Geral

Patch de correções críticas do **Reconstruir Banco de Dados** e sincronização do estoque. Corrige a subtração das vendas que não estava sendo aplicada ao estoque exibido, elimina contagem duplicada de PDFs de venda que estavam na raiz do repositório e garante que a tela de Estoque atualiza automaticamente após a reconstrução.

---

## 🐛 Correções

### 1. Tela de Estoque não atualizava após Reconstruir Banco

**Causa:** `EstoqueViewModel.Recarregar()` só era chamado quando o `DataContext` da view era atribuído pela primeira vez (ao navegar pela primeira vez para a tela). Como `EstoqueVM` é uma instância única, reconstruir o banco em `PesagensViewModel` gravava o novo `estoque.json` no disco, mas a tela de Estoque continuava exibindo os dados antigos em memória.

**Correção:**
- Adicionado `EstoqueRecarregarCallback` em `PesagensViewModel`.
- Chamado ao final de `ReconstruirBancoDadosAsync` com sucesso.
- Conectado em `MainWindowViewModel`:
  ```csharp
  PesagensVM.EstoqueRecarregarCallback = () => EstoqueVM.Recarregar();
  ```

**Arquivos alterados:**
- `ViewModels/PesagensViewModel.cs`
- `ViewModels/MainWindowViewModel.cs`

---

### 2. PDF de venda na raiz de `Recibos/` era contado como pesagem

**Causa:** O arquivo `ESTOQUE_FINAL_29-05-2026.pdf` (e potencialmente outros) existia tanto em `Recibos/` (raiz) quanto em `Recibos/Recibos_Venda/`. O `Reconstruir` processava todos os PDFs da raiz como pesagens — inflando o total — e depois o mesmo arquivo era subtraído como venda, gerando inconsistência.

**Correção:** Antes de listar os PDFs de pesagem, o `ReconstruirBancoDadosService` agora constrói um `HashSet` com os nomes de arquivos presentes em `Recibos_Venda/` e **exclui** da fase de pesagem qualquer PDF cujo nome coincida:

```csharp
var nomesVenda = new HashSet<string>(
    Directory.GetFiles(vendaDir, "*.pdf").Select(Path.GetFileName)!,
    StringComparer.OrdinalIgnoreCase);

var pdfs = Directory.GetFiles(recibosDir, "*.pdf", SearchOption.TopDirectoryOnly)
    .Where(f => !nomesVenda.Contains(Path.GetFileName(f)))
    ...
```

**Arquivos alterados:**
- `Services/ReconstruirBancoDadosService.cs`

---

### 3. Parser de pesos (`ReciboParserService`) não reconhecia ponto decimal

**Causa:** PDFs de venda gerados antes da correção de cultura (V5.0.0) usavam ponto como separador decimal (ex: `19.129`). O regex `_rePeso` só reconhecia vírgula (ex: `19,129`).

**Correção:**
- Regex estendido com terceiro grupo `(\d+\.\d{3})` para capturar formato invariant.
- `ExtrairPrimeiroPeso` adaptado para distinguir os dois formatos:
  - Com vírgula → trata como pt-BR (`1.234,567` → `1234.567`)
  - Com ponto sem vírgula → trata como invariant (`1.258` → parse direto)

**Arquivos alterados:**
- `Services/ReciboParserService.cs`

---

### 4. Log de diagnóstico gravado em disco após Reconstruir Banco

Para facilitar diagnóstico de problemas futuros, o `ReconstruirBancoDadosService` agora grava um arquivo de log completo em:

```
~/Downloads/ControleMateriaisLFB/reconstruir-banco.log
```

O log contém timestamp, nome de cada PDF processado, itens extraídos e avisos de itens não reconhecidos ou não encontrados no estoque.

---

### 5. Versão atualizada para V5.0.1

Label na tela inicial (`HomeView`) atualizado de `V5.0.0` para `V5.0.1`.

---

## 🔧 Arquivos Modificados

```
ControleMateriais.Desktop/
├── ViewModels/
│   ├── PesagensViewModel.cs        — EstoqueRecarregarCallback declarado e invocado
│   └── MainWindowViewModel.cs      — EstoqueRecarregarCallback conectado ao EstoqueVM
├── Services/
│   ├── ReconstruirBancoDadosService.cs — exclusão de PDFs de venda da fase de pesagem,
│   │                                     logging detalhado em disco
│   └── ReciboParserService.cs      — regex e parser adaptados para ponto decimal
└── Views/
    └── HomeView.axaml              — versão V5.0.1
```

---

**Versão**: Release 5.0.1  
**Branch**: `Release/4.0`  
**Data**: 2026-06-19  
**Responsável**: Gabriel Stundner  
**Repositório**: `lfbreciclagemeletronica/Controle-Materiais`
